### PR TITLE
Add mechanism to identify cluster is ready for installation

### DIFF
--- a/src/components/clusterConfiguration/ClusterValidationSection.css
+++ b/src/components/clusterConfiguration/ClusterValidationSection.css
@@ -1,0 +1,3 @@
+.cluster-validation-section {
+  padding-bottom: var(--pf-global--spacer--md) !important;
+}

--- a/src/components/clusterConfiguration/ClusterValidationSection.tsx
+++ b/src/components/clusterConfiguration/ClusterValidationSection.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { FormikErrors } from 'formik';
+import {
+  AlertGroup,
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import { Cluster } from '../../api/types';
+import { validateCluster } from './clusterValidations';
+import { ClusterConfigurationValues } from '../../types/clusters';
+import { CLUSTER_FIELD_LABELS } from '../../config/constants';
+import './ClusterValidationSection.css';
+
+type ClusterValidationSectionProps = {
+  cluster: Cluster;
+  dirty: boolean;
+  formErrors: FormikErrors<ClusterConfigurationValues>;
+  onClose: () => void;
+};
+
+const ClusterValidationSection: React.FC<ClusterValidationSectionProps> = ({
+  cluster,
+  dirty,
+  formErrors,
+  onClose,
+}) => {
+  const prevReadyRef = React.useRef<boolean>();
+  const errors = React.useMemo(() => validateCluster(cluster), [cluster]);
+  const errorFields = Object.keys(formErrors);
+  const ready = cluster.status === 'ready' && !errors.length && !errorFields.length && !dirty;
+
+  // When cluster becomes ready, close this section
+  React.useEffect(() => {
+    if (prevReadyRef.current === false && ready === true) {
+      onClose();
+    } else {
+      prevReadyRef.current = ready;
+    }
+  });
+
+  return (
+    <Split>
+      <SplitItem isFilled>
+        <AlertGroup className="cluster-validation-section">
+          {!errorFields.length && dirty && (
+            <Alert
+              variant={AlertVariant.info}
+              title="There are unsaved changes to the cluster configuration"
+              isInline
+            >
+              Please save or discard the pending cluster configuration changes.
+            </Alert>
+          )}
+          {!!errorFields.length && (
+            <Alert
+              variant={AlertVariant.danger}
+              title="Provided cluster configuration is not valid"
+              isInline
+            >
+              Following fields have invalid value set:{' '}
+              {errorFields.map((field: string) => CLUSTER_FIELD_LABELS[field]).join(', ')}.
+            </Alert>
+          )}
+          {(cluster.status !== 'ready' || !!errors.length) && (
+            <Alert
+              variant={AlertVariant.warning}
+              title="Cluster is not ready to be installed yet"
+              isInline
+            >
+              {!!errors.length && (
+                <ul>
+                  {errors.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+                </ul>
+              )}
+            </Alert>
+          )}
+        </AlertGroup>
+      </SplitItem>
+      <SplitItem>
+        <Button variant={ButtonVariant.plain} onClick={onClose} aria-label="Close">
+          <TimesIcon />
+        </Button>
+      </SplitItem>
+    </Split>
+  );
+};
+
+export default ClusterValidationSection;

--- a/src/components/clusterConfiguration/clusterValidations.ts
+++ b/src/components/clusterConfiguration/clusterValidations.ts
@@ -1,0 +1,60 @@
+import * as _ from 'lodash';
+import * as Yup from 'yup';
+import { validateYupSchema, yupToFormErrors } from 'formik';
+import { Cluster } from '../../api/types';
+import { ClusterConfigurationValues } from '../../types/clusters';
+import {
+  pullSecretKnownOrRequired,
+  sshPublicKeyValidationSchema,
+} from '../ui/formik/validationSchemas';
+import { getInitialValues } from './utils';
+import { CLUSTER_FIELD_LABELS } from '../../config/constants';
+
+export const validateHosts = (cluster: Cluster) => {
+  const hosts = cluster.hosts || [];
+  const masters = hosts.filter((r) => r.role === 'master').length;
+  if (hosts.length < 3) {
+    return `Cluster has insufficient number of hosts registered. Please register at least 3 hosts.`;
+  }
+  if (masters < 3) {
+    return `Cluster with ${masters} masters is not supported. Please choose at least 3 master hosts.`;
+  }
+  if (masters % 2 === 0) {
+    return `Cluster with ${masters} masters is not supported. Please set an odd number of master hosts.`;
+  }
+  const readyMasters =
+    cluster.hosts?.filter((host) => host.role === 'master' && host.status === 'known') || [];
+  if (readyMasters.length < 3) {
+    return `Cluster has insufficient number of hosts ready for installation. Minimum of 3 master hosts in 'Known' state is required.`;
+  }
+};
+
+// TODO(jtomasek): Add validation to identify hosts which are connected to network defined by VIPs
+// const validateConnectedHosts = (cluster: Cluster) => ...;
+
+export const validateRequiredFields = (cluster: Cluster) => {
+  const values = getInitialValues(cluster);
+  const requiredSchema = Yup.mixed().required();
+
+  const installValidationSchema = Yup.object<ClusterConfigurationValues>().shape({
+    baseDnsDomain: requiredSchema,
+    clusterNetworkHostPrefix: requiredSchema,
+    clusterNetworkCidr: requiredSchema,
+    serviceNetworkCidr: requiredSchema,
+    apiVip: requiredSchema,
+    ingressVip: requiredSchema,
+    pullSecret: pullSecretKnownOrRequired(values),
+    sshPublicKey: sshPublicKeyValidationSchema,
+  });
+  try {
+    validateYupSchema<ClusterConfigurationValues>(values, installValidationSchema, true);
+  } catch (err) {
+    const errors = yupToFormErrors(err);
+    const errorFields = Object.keys(errors).map((field: string) => CLUSTER_FIELD_LABELS[field]);
+    return `Not all required cluster properties are configured yet: ${errorFields.join(', ')}.`;
+  }
+};
+
+export const validateCluster = (cluster: Cluster) => {
+  return _.filter([validateHosts(cluster), validateRequiredFields(cluster)]);
+};

--- a/src/components/clusterConfiguration/utils.ts
+++ b/src/components/clusterConfiguration/utils.ts
@@ -1,0 +1,66 @@
+import { Netmask } from 'netmask';
+import { HostSubnets, ClusterConfigurationValues } from '../../types/clusters';
+import { Cluster, Inventory } from '../../api/types';
+import { stringToJSON } from '../../api/utils';
+
+export const findMatchingSubnet = (
+  ingressVip: string | undefined,
+  apiVip: string | undefined,
+  hostSubnets: HostSubnets,
+): string => {
+  let matchingSubnet;
+  if (hostSubnets.length) {
+    if (!ingressVip && !apiVip) {
+      matchingSubnet = hostSubnets[0];
+    } else {
+      matchingSubnet = hostSubnets.find((hn) => {
+        let found = true;
+        if (ingressVip) {
+          found = found && hn.subnet.contains(ingressVip);
+        }
+        if (apiVip) {
+          found = found && hn.subnet.contains(apiVip);
+        }
+        return found;
+      });
+    }
+  }
+  return matchingSubnet ? matchingSubnet.humanized : 'No subnets available';
+};
+
+export const getHostSubnets = (cluster: Cluster): HostSubnets => {
+  const hostnameMap: { [id: string]: string } =
+    cluster.hosts?.reduce((acc, host) => {
+      const inventory = stringToJSON<Inventory>(host.inventory) || {};
+      acc = {
+        ...acc,
+        [host.id]: inventory.hostname,
+      };
+      return acc;
+    }, {}) || {};
+
+  return (
+    cluster.hostNetworks?.map((hn) => {
+      const subnet = new Netmask(hn.cidr as string);
+      return {
+        subnet,
+        hostIDs: hn.hostIds?.map((id) => hostnameMap[id] || id) || [],
+        humanized: `${subnet.first}-${subnet.last}`,
+      };
+    }) || []
+  );
+};
+
+export const getInitialValues = (cluster: Cluster): ClusterConfigurationValues => ({
+  name: cluster.name || '',
+  baseDnsDomain: cluster.baseDnsDomain || '',
+  clusterNetworkCidr: cluster.clusterNetworkCidr || '',
+  clusterNetworkHostPrefix: cluster.clusterNetworkHostPrefix || 0,
+  serviceNetworkCidr: cluster.serviceNetworkCidr || '',
+  apiVip: cluster.apiVip || '',
+  ingressVip: cluster.ingressVip || '',
+  pullSecret: '',
+  sshPublicKey: cluster.sshPublicKey || '',
+  isPullSecretEdit: !cluster.pullSecretSet, // toggles edit mode and drives validation
+  hostSubnet: findMatchingSubnet(cluster.ingressVip, cluster.apiVip, getHostSubnets(cluster)),
+});

--- a/src/components/clusters/ClusterToolbar.tsx
+++ b/src/components/clusters/ClusterToolbar.tsx
@@ -4,11 +4,12 @@ import PageSection from '../ui/PageSection';
 import './ClusterToolbar.css';
 
 interface Props {
-  children: React.ReactNode;
+  validationSection?: React.ReactNode;
 }
 
-const ClusterToolbar: React.FC<Props> = ({ children }) => (
+const ClusterToolbar: React.FC<Props> = ({ children, validationSection }) => (
   <PageSection variant={PageSectionVariants.light} className="pf-u-box-shadow-lg-top">
+    {validationSection}
     <Toolbar id="cluster-toolbar" className="cluster-toolbar">
       <ToolbarContent className="cluster-toolbar__content">{children}</ToolbarContent>
     </Toolbar>

--- a/src/components/hosts/RoleDropdown.tsx
+++ b/src/components/hosts/RoleDropdown.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { Host, ClusterUpdateParams } from '../../api/types';
 import { SimpleDropdown } from '../ui/SimpleDropdown';
 import { patchCluster } from '../../api/clusters';
-import { HostRolesType, HOST_ROLES } from '../../config/constants';
+import { Role, HOST_ROLES } from '../../config/constants';
 import { updateCluster } from '../../features/clusters/currentClusterSlice';
 import { handleApiError } from '../../api/utils';
 
@@ -19,7 +19,7 @@ export const RoleDropdown: React.FC<RoleDropdownProps> = ({ host }) => {
   const setRole = async (role?: string) => {
     const params: ClusterUpdateParams = {};
     setDisabled(true);
-    params.hostsRoles = [{ id, role: role as HostRolesType }];
+    params.hostsRoles = [{ id, role: role as Role }];
     try {
       const { data } = await patchCluster(clusterId as string, params);
       dispatch(updateCluster(data));

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -22,7 +22,7 @@ export const EVENTS_POLLING_INTERVAL = 10 * 1000;
 
 export const HOST_ROLES = ['worker', 'master'];
 // Without undefined. Otherwise must conform generated Host['roles'] - see api/types.ts
-export type HostRolesType = 'master' | 'worker';
+export type Role = 'master' | 'worker' | undefined;
 
 export const CLUSTER_STATUS_LABELS: { [key in Cluster['status']]: string } = {
   insufficient: 'Draft',
@@ -42,6 +42,18 @@ export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
   'installing-in-progress': 'Installing',
   installed: 'Installed',
   error: 'Error',
+};
+
+export const CLUSTER_FIELD_LABELS: { [key in string]: string } = {
+  name: 'Cluster Name',
+  baseDnsDomain: 'Base DNS Domain',
+  clusterNetworkCidr: 'Cluster Network CIDR',
+  clusterNetworkHostPrefix: 'Cluster Network Host Prefix',
+  serviceNetworkCidr: 'Service Network CIDR',
+  apiVip: 'API Virtual IP',
+  ingressVip: 'Ingress Virtual IP',
+  pullSecret: 'Pull Secret',
+  sshPublicKey: 'SSH Public Key',
 };
 
 export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {


### PR DESCRIPTION
- Add ClusterValidationSection to ClusterToolbar to expose current
  cluster configuration problems
- Add cluster validations which are calculated on every cluster update
- Simplify install validation mechanism by moving the logic from the
  form into the cluster based validations
- Separate the 'Save Changes' and 'Install Cluster' logic
- Add 'Discard Changes' button to allow rolling back form changes
- Refactor utility functions from ClusterConfiguration into a separate
  module

<img width="1336" alt="Screenshot 2020-06-10 at 23 43 26" src="https://user-images.githubusercontent.com/1121740/84321937-6eb2f780-ab74-11ea-9d82-e3412c1206d6.png">
<img width="1337" alt="Screenshot 2020-06-10 at 23 44 06" src="https://user-images.githubusercontent.com/1121740/84321950-7377ab80-ab74-11ea-9d93-5a12ad1b6619.png">
<img width="1335" alt="Screenshot 2020-06-10 at 23 44 33" src="https://user-images.githubusercontent.com/1121740/84321957-76729c00-ab74-11ea-99ed-749305d55da3.png">
