### PR TITLE
Changes after facet to openshift-assisted/assisted-ui transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,14 @@
-![](https://github.com/openshift-metal3/facet/workflows/Build%20and%20push/badge.svg)
+![](https://github.com/openshift-assisted/assisted-ui/workflows/Build%20and%20push/badge.svg)
 
-# Facet
+# The Assisted Installer User Insterface
 
-OpenShift Metal³ installer UI.
+The Assisted Installer makes IPI (Installer-Provisioned Infrastructure) OpenShift cluster deployments on bare metal easy.
 
-Facet is the central integration point for doing a Metal³ deployment of OpenShift. It’s the one
-command you run on a provisioning host to kick off the deployment. It performs the following
-functions:
+Hosts building the cluster are discovered by booting an ISO image downloaded from the Assisted Installer.
 
-- Implements the day 1 provisioning API. In other words, this API provides what is necessary to get
-  the masters providing the control plane up and running. From that point, the Machine API and the
-  corresponding Metal³ components will take over provisioning the rest of the cluster.
+By entering a few neccessary configuration details (like cluster name, base domain, SSH public keys or netowrk specifics), the Assisted Installer handles all the deployement and configuration automatically, resulting in a ready-to-use cluster.
 
-- Will do provisioning host configuration validation at startup.
-
-- Will launch the Ironic containers using podman on the provisioning host.
-
-- Will download the current images of RHCOS that are needed for deployment. (for the bootstrap VM
-  and bare metal hosts)
-
-- Will run the installer, launch the bootstrap VM, and drive Ironic APIs.
-
-Here's a diagram of the Facet architecture: ![Facet Architecture](/images/Facet_Architecture.png)
-
-For further details about the Metal³ architecture, see [http://github.com/metal3-io/metal3-docs].
+This project is a user interface backed by Assisted Installer API.
 
 ## Getting started
 
@@ -35,8 +20,8 @@ For further details about the Metal³ architecture, see [http://github.com/metal
   ```
 - Clone repo:
   ```
-  git clone https://github.com/openshift-metal3/facet.git
-  cd facet
+  git clone https://github.com/openshift-assisted/assisted-ui.git
+  cd assisted-ui
   ```
 
 ### Build and run in DEV-mode
@@ -115,20 +100,6 @@ $ REACT_APP_BUILD_MODE=single-cluster yarn build
 ## Available Scripts
 
 In the project directory, you can run:
-
-### `hacks/npm-publish.sh`
-
-Increases `patch` version (`.z`) of the package, opens PR with this change and **publishes** the
-package to the [npmjs.com](https://www.npmjs.com/package/metal3-facet) repository.
-
-New tag conforming the version is created.
-
-Prior running this script, please be sure you
-
-- are logged in npmjs.com (call `yarn login`)
-
-- can create branches and open PRs in
-  [https://github.com/openshift-metal3/facet](https://github.com/openshift-metal3/facet)
 
 ### `yarn install`
 

--- a/hacks/README.md
+++ b/hacks/README.md
@@ -3,9 +3,9 @@
 These scripts simplify builds, deployments or development.
 
 ## update-assisted-ui-lib
-Can be executed right after `assisted-ui-lib` release to update it's version in
-- the facet application
-- the uhc-portal (OCM)
+Can be executed right after creating a new `assisted-ui-lib` [release](https://github.com/openshift-assisted/assisted-ui-lib/releases) to update it's version in the
+- assisted-ui application
+- uhc-portal (OCM)
 
 **Please see `The Release Process` section bellow before using it.**
 
@@ -28,9 +28,9 @@ Used to create a virtual machine from an ISO (like a discovery iso), tested in o
 See comments inside the script for further details.
 
 # The Release Process
-Please note, the `facet` application features heavily depend on the `openshift-assisted-ui-lib` JavaSript library which needs to be released along the `facet` application.
+Please note, the `assisted-ui` application features heavily depend on the `openshift-assisted-ui-lib` JavaSript library. So both projects need to be released in sync.
 
-Recently release versions of both project are alligned to simplify testing.
+To simplify testing, release versions of both projects are alligned recently.
 
 ## Prerequisities
 - Have [uhc-portal](https://gitlab.cee.redhat.com/service/uhc-portal) fork
@@ -39,8 +39,8 @@ Recently release versions of both project are alligned to simplify testing.
 ## Steps
 
 When releasing new version, following steps are executed:
-- **Approve and merge** open PRs in both
-  - [facet pull requests](https://github.com/openshift-metal3/facet/pulls)
+- **Approve and merge** open PRs intended to be part of the new release in both
+  - [assisted-ui pull requests](https://github.com/openshift-assisted/assisted-ui/pulls)
   - [assisted-ui-lib pull requests](https://github.com/openshift-assisted/assisted-ui-lib/pulls)
 
 - **Release** [openshift-assisted-ui-lib via GitHub](https://github.com/openshift-assisted/assisted-ui-lib/releases/new)
@@ -59,18 +59,18 @@ When releasing new version, following steps are executed:
     - *Note:* It is a GitHub's feature that an action can not trigger execution of another action. So without close/reopen the CI will not be executed on this PR.
   - **Wait till** new `openshift-assisted-ui-lib` version is automatically published to [npmjs.com](https://www.npmjs.com/package/openshift-assisted-ui-lib)
 
-- **Update** `openshift-assisted-ui-lib` in the `facet` and `uhc-portal` via
+- **Update** `openshift-assisted-ui-lib` in the `assisted-ui` and `uhc-portal` via
   - ```
-     $ curl https://raw.githubusercontent.com/openshift-metal3/facet/master/hacks/update-assisted-ui-lib.sh | sh -
+     $ curl https://raw.githubusercontent.com/openshift-assisted/assisted-ui/master/hacks/update-assisted-ui-lib.sh | sh -
     ```
     - Watch output of the script. It might happen in rare cases that new `openshift-assisted-ui-lib` version is not automatically found (i.e. due to short delay), so you can force it by:
       ```
-      $ curl https://raw.githubusercontent.com/openshift-metal3/facet/master/hacks/update-assisted-ui-lib.sh | ASSISTED_UI_LIB_VERSION=1.5.0 sh -
+      $ curl https://raw.githubusercontent.com/openshift-assisted/assisted-ui/master/hacks/update-assisted-ui-lib.sh | ASSISTED_UI_LIB_VERSION=1.5.0 sh -
       ```
 - New browser tabs are opened, **finish the process** there by:
   - merge `assisted-ui-lib` version update (if you missed that in the steps above)
   - open a merge request to `uhc-portal`
-  - confirm new `facet` project release - **append** description if needed
+  - confirm new `assisted-ui` project release - **append** description if needed
 - Pass through all Jira and Bugzilla tickets and **fill `Fixed in version`**
   - use [assisted-ui-lib's release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases) to guide you
   - *Note:* We are working on automating this step

--- a/hacks/create-test-vm.sh
+++ b/hacks/create-test-vm.sh
@@ -7,7 +7,7 @@ set -e
 #
 # Example for day 2 host:
 #   - download generated Day 2 iso under /var/lib/libvirt/images/
-#   $ curl https://raw.githubusercontent.com/openshift-metal3/facet/master/hacks/create-test-vm.sh | ISO=/var/lib/libvirt/images/discovery_image_scale-up-mlibra11.iso NAME=mlibra11_worker_7 sh -
+#   $ curl https://raw.githubusercontent.com/openshift-assisted/assisted-ui/master/hacks/create-test-vm.sh | ISO=/var/lib/libvirt/images/discovery_image_scale-up-mlibra11.iso NAME=mlibra11_worker_7 sh -
 #
 # Provide additional parameters for day 1 masters (at least set MEMGIB and CPUS env variables)
  

--- a/hacks/update-assisted-ui-lib.sh
+++ b/hacks/update-assisted-ui-lib.sh
@@ -14,8 +14,8 @@ echo GITHUB_USER: $GITHUB_USER
 export GITLAB_USER=${GITLAB_USER:-"`whoami`"}
 echo GITLAB_USER: $GITLAB_USER
 
-export FACET_USER_REPO=${FACET_USER_REPO:-"https://github.com/${GITHUB_USER}/facet.git"}
-echo FACET_USER_REPO: $FACET_USER_REPO
+export ASSISTED_UI_USER_REPO=${ASSISTED_UI_USER_REPO:-"https://github.com/${GITHUB_USER}/assisted-ui.git"}
+echo ASSISTED_UI_USER_REPO: $ASSISTED_UI_USER_REPO
 
 export UHC_PORTAL_REPO=${UHC_PORTAL_REPO:-"https://gitlab.cee.redhat.com/${GITLAB_USER}/uhc-portal.git"}
 echo UHC_PORTAL_REPO: ${UHC_PORTAL_REPO}
@@ -23,15 +23,15 @@ echo UHC_PORTAL_REPO: ${UHC_PORTAL_REPO}
 export TAG=${TAG:-"assisted-ui-lib-${ASSISTED_UI_LIB_VERSION}"}
 export UPDATE_BRANCH="assisted-ui-lib.auto.v${ASSISTED_UI_LIB_VERSION}"
 
-export TMPDIR=`mktemp -d /tmp/facet-XXXX`
+export TMPDIR=`mktemp -d /tmp/assisted-ui-XXXX`
 echo TMPDIR: $TMPDIR
 
-# update facet
-echo -e "${GREEN_COLOR}Updating facet${NC}"
+# update assisted-ui
+echo -e "${GREEN_COLOR}Updating assisted-ui${NC}"
 cd ${TMPDIR}
-git clone ${FACET_USER_REPO}
-cd facet
-git remote add upstream https://github.com/openshift-metal3/facet.git
+git clone ${ASSISTED_UI_USER_REPO}
+cd assisted-ui
+git remote add upstream https://github.com/openshift-assisted/assisted-ui.git
 git fetch --all && git reset --hard upstream/master
 git checkout -b ${UPDATE_BRANCH}
 
@@ -69,15 +69,16 @@ cd ${TMPDIR}/uhc-portal
 echo Pushing to ${UHC_PORTAL_REPO} to create a merge request there
 git push --set-upstream origin ${UPDATE_BRANCH}
 
-cd ${TMPDIR}/facet
-echo Pushing to ${FACET_USER_REPO} to create a pull request there
+cd ${TMPDIR}/assisted-ui
+echo Pushing to ${ASSISTED_UI_USER_REPO} to create a pull request there
 git push --set-upstream origin ${UPDATE_BRANCH} --follow-tags
 
 # The last mile in a browser for convenience
 xdg-open "https://github.com/openshift-assisted/assisted-ui-lib/pulls" & # to close/re-open generated PR (optional)
 xdg-open "https://gitlab.cee.redhat.com/${GITLAB_USER}/uhc-portal/-/merge_requests/new?merge_request%5Bsource_branch%5D=${UPDATE_BRANCH}&merge_request%5Btitle%5D=WIP: Update openshift-assisted-ui-lib to ${ASSISTED_UI_LIB_VERSION}&merge_request%5Bdescription%5D=TODO: Removae WIP when phase1 testing passed to unblock review and merge here" &
-xdg-open "https://github.com/openshift-metal3/facet/releases/new?tag=v${ASSISTED_UI_LIB_VERSION}&title=v${ASSISTED_UI_LIB_VERSION}&body=REMOVE THIS REMINDER: Do not forget to merge pull-request with openshift-assisted-ui-lib update BEFORE creating new release here.%0A%0A${TAG}: https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v${ASSISTED_UI_LIB_VERSION}" &
-xdg-open https://github.com/${GITHUB_USER}/facet/pull/new/${UPDATE_BRANCH} & # <--- Pay attention to this before creating a new release in facet!
+xdg-open "https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v${ASSISTED_UI_LIB_VERSION}&title=v${ASSISTED_UI_LIB_VERSION}&body=REMOVE THIS REMINDER: Do not forget to merge pull-request with openshift-assisted-ui-lib update BEFORE creating new release here.%0A%0A${TAG}: https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v${ASSISTED_UI_LIB_VERSION}" &
 
-echo -e "All set. Continue by create and ${GREEN_COLOR}merge${NC} Pull Request in the facet project"
+xdg-open "https://github.com/${GITHUB_USER}/assisted-ui/pull/new/${UPDATE_BRANCH}" & # <--- Pay attention to this before creating a new release in teh assisted-ui!
+
+echo -e "All set. Continue by create and ${GREEN_COLOR}merge${NC} Pull Request in the assisted-ui project"
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "metal3-facet",
+  "name": "openshift-assisted-ui",
   "version": "0.1.4",
   "private": false,
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/openshift-metal3/facet/issues"
+    "url": "https://github.com/openshift-assisted/assisted-ui/issues"
   },
   "dependencies": {
     "@patternfly/react-core": "^4.63.3",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Facet",
-  "name": "Metal³ Facet - user interface to drive bare metal Kubernetes cluster deployment",
+  "short_name": "Assisted Installer UI",
+  "name": "Assisted Installer UI - user interface to drive bare metal OpenShift cluster deployment",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Brand, PageHeader, PageHeaderTools, Button, ButtonVariant } from '@patternfly/react-core';
 import { Config } from 'openshift-assisted-ui-lib';
-import metal3FacetLogo from '../../images/metal3_facet-whitetext.png';
+import upstreamLogo from '../../images/metal3_facet-whitetext.png';
 import redhatLogo from '../../images/Logo-Red_Hat-OpenShift_Container_Platform-B-Reverse-RGB.png';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import AboutModalButton from '../AboutModal';
@@ -18,9 +18,9 @@ const getBrandingDetails = () => {
       };
     default:
       return {
-        logo: metal3FacetLogo,
-        alt: 'Metal&sup3; Facet UI',
-        href: 'https://github.com/openshift-metal3/facet',
+        logo: upstreamLogo,
+        alt: 'Assisted Installer UI',
+        href: 'https://github.com/openshift-assisted/assisted-ui',
       };
   }
 };


### PR DESCRIPTION
Ownership and name of the "facet" project has been changed to openshift-assisted/assisted-ui.

Counterpart: https://github.com/openshift-assisted/assisted-ui-lib/pull/378