### PR TITLE
Increasing timeout for cluster creation page.

### DIFF
--- a/cypress/integration/shared.js
+++ b/cypress/integration/shared.js
@@ -89,7 +89,9 @@ export const createCluster = (cy, clusterName, pullSecret) => {
 
   // Cluster configuration
   // cy.get('.pf-c-breadcrumb__list > :nth-child(2)').contains(clusterName);
-  cy.get('#bare-metal-inventory-button-download-discovery-iso').should('be.visible');
+  cy.get('#bare-metal-inventory-button-download-discovery-iso', { timeout: 10 * 1000 }).should(
+    'be.visible',
+  );
   cy.get('#form-input-name-field').should('have.value', clusterName);
 };
 


### PR DESCRIPTION
The existing 5 seconds timeout isn't enough when
PSI is loaded. Bumping the timeout to 10 seconds.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>