### PR TITLE
Update assisted-ui-lib to v1.5.2

### DIFF
--- a/hacks/update-assisted-ui-lib.sh
+++ b/hacks/update-assisted-ui-lib.sh
@@ -26,6 +26,11 @@ export UPDATE_BRANCH="assisted-ui-lib.auto.v${ASSISTED_UI_LIB_VERSION}"
 export TMPDIR=`mktemp -d /tmp/assisted-ui-XXXX`
 echo TMPDIR: $TMPDIR
 
+# Helper functions
+function uriencode {
+  jq -nr --arg v "$1" '$v|@uri';
+}
+
 # update assisted-ui
 echo -e "${GREEN_COLOR}Updating assisted-ui${NC}"
 cd ${TMPDIR}
@@ -75,10 +80,12 @@ git push --set-upstream origin ${UPDATE_BRANCH} --follow-tags
 
 # The last mile in a browser for convenience
 xdg-open "https://github.com/openshift-assisted/assisted-ui-lib/pulls" & # to close/re-open generated PR (optional)
-xdg-open "https://gitlab.cee.redhat.com/${GITLAB_USER}/uhc-portal/-/merge_requests/new?merge_request%5Bsource_branch%5D=${UPDATE_BRANCH}&merge_request%5Btitle%5D=WIP: Update openshift-assisted-ui-lib to ${ASSISTED_UI_LIB_VERSION}&merge_request%5Bdescription%5D=TODO: Removae WIP when phase1 testing passed to unblock review and merge here" &
-xdg-open "https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v${ASSISTED_UI_LIB_VERSION}&title=v${ASSISTED_UI_LIB_VERSION}&body=REMOVE THIS REMINDER: Do not forget to merge pull-request with openshift-assisted-ui-lib update BEFORE creating new release here.%0A%0A${TAG}: https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v${ASSISTED_UI_LIB_VERSION}" &
 
-xdg-open "https://github.com/${GITHUB_USER}/assisted-ui/pull/new/${UPDATE_BRANCH}" & # <--- Pay attention to this before creating a new release in teh assisted-ui!
+xdg-open "https://gitlab.cee.redhat.com/${GITLAB_USER}/uhc-portal/-/merge_requests/new?merge_request%5Bsource_branch%5D=${UPDATE_BRANCH}&merge_request%5Btitle%5D=WIP: Update openshift-assisted-ui-lib to ${ASSISTED_UI_LIB_VERSION}&merge_request%5Bdescription%5D=TODO: Remove the WIP when phase1 testing passes overnight. Until then the review and merge is blocked here." &
+
+export LIB_RELEASE_URL=`uriencode "${TAG}: https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v${ASSISTED_UI_LIB_VERSION}"`
+export RELEASE_URL=`uriencode "https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v${ASSISTED_UI_LIB_VERSION}&title=v${ASSISTED_UI_LIB_VERSION}&body=${LIB_RELEASE_URL}"`
+xdg-open "https://github.com/openshift-assisted/assisted-ui/compare/master...${GITHUB_USER}:${UPDATE_BRANCH}?expand=1&pull_request%5Bbody%5D=Instructions: Once this PR is merged, continue by creating a new release here:%0A${RELEASE_URL}"
 
 echo -e "All set. Continue by create and ${GREEN_COLOR}merge${NC} Pull Request in the assisted-ui project"
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
     "node-sass": "^4.13.1",
-    "openshift-assisted-ui-lib": "^1.5.1-1",
+    "openshift-assisted-ui-lib": "^1.5.2",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8621,10 +8621,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.1-1:
-  version "1.5.1-1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.1-1.tgz#1f9ab342b093162fdcb223b9287f785c9bb22e0c"
-  integrity sha512-VFA+iVOxR+M12hV/pLVV+iPC5UaQw46B6PA/PhjixZkU1ZW5u9gD/OzwYTR9HySuy9VF+VdHOntMM5lB4zfNaw==
+openshift-assisted-ui-lib@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.2.tgz#b6b3624acae651624d870432abc35b2ab493b2eb"
+  integrity sha512-QZeDU/E+7hAksguK8eEPDKwS4SZJ7zFAcVTlTRtsfkxz8uadmz2k3mCtYQsfAQJWRssl8xBhVOynTccJJvDmTQ==
   dependencies:
     axios-case-converter "^0.6.0"
     ip-address "^7.1.0"


### PR DESCRIPTION
In addition, the `update-assisted-ui-lib.sh` newly enforces update of the `assisted-ui` for a new `assisted-ui-lib release **BEFORE** creating a new assisted-ui release to eliminate mistake.