### PR TITLE
Update openshift-assisted-ui-lib to 1.5.2-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
     "node-sass": "^4.13.1",
-    "openshift-assisted-ui-lib": "^1.5.2",
+    "openshift-assisted-ui-lib": "^1.5.2-1",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8621,10 +8621,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.2.tgz#b6b3624acae651624d870432abc35b2ab493b2eb"
-  integrity sha512-QZeDU/E+7hAksguK8eEPDKwS4SZJ7zFAcVTlTRtsfkxz8uadmz2k3mCtYQsfAQJWRssl8xBhVOynTccJJvDmTQ==
+openshift-assisted-ui-lib@^1.5.2-1:
+  version "1.5.2-1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.2-1.tgz#3a7770bb6ec19b4661596fb72ffbd636d786fafd"
+  integrity sha512-6oZPU6U1A6lkeOrqc8XBSnsRQutWRa097bz+0F/WgMF2rHxAZYfRdEgu7NWxc6K/fn9RUXpifyW2gTPpv3zf7w==
   dependencies:
     axios-case-converter "^0.6.0"
     ip-address "^7.1.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.2-1&title=v1.5.2-1&body=assisted-ui-lib-1.5.2-1%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.2-1