### PR TITLE
Update openshift-assisted-ui-lib to 1.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
     "node-sass": "^4.13.1",
-    "openshift-assisted-ui-lib": "^1.5.3-1",
+    "openshift-assisted-ui-lib": "^1.5.4",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8607,10 +8607,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.3-1:
-  version "1.5.3-1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.3-1.tgz#51cfab23139cc031be838ce27c247716a910512a"
-  integrity sha512-UdWyYZkoeXTD9lHtSGgTE2caoA+chYNk49LmZ5sSfFwkIeZ2pi/eZDBV8e5PkQvn7ilIWzlwkmIjA4iQFuH+Tg==
+openshift-assisted-ui-lib@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.4.tgz#fa974ec83c82ba7de05620d758dc974983c8d410"
+  integrity sha512-TmVIYcQlC4lrZbLRwsC8qyogJm5zYdMAHnS345iDQO5XZYPs4T/BgMmFWINFDsa92LGtM6Ks1r/f476mddZ5Sg==
   dependencies:
     axios-case-converter "^0.6.0"
     ip-address "^7.1.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.4&title=v1.5.4&body=assisted-ui-lib-1.5.4%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.4