### PR TITLE
Update openshift-assisted-ui-lib to 1.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
     "node-sass": "^4.13.1",
-    "openshift-assisted-ui-lib": "^1.5.6",
+    "openshift-assisted-ui-lib": "^1.5.7",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8690,10 +8690,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.6:
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.6.tgz#30898befd5f564c22a4f41e9c923fdcd703698c2"
-  integrity sha512-3EB4CkxsIv5lMJi6pfJpnuz7Ci182yH+tPntNF8rJMEAElOTWN2kEOoOoOt+SLEeQiQb/tlaaSXzyVaNRpTIWQ==
+openshift-assisted-ui-lib@^1.5.7:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.7.tgz#7dc8a6372b0d25ad761b28f26160182918e08aab"
+  integrity sha512-dLhMqbKBBf+WiTwJgReWD95XxWAEROWVYNxkA9Ri8fZxQNc8L0PccP1y6ZsePObBkN7VHGAka5PJl6wKpqK/ng==
   dependencies:
     axios-case-converter "^0.6.0"
     ip-address "^7.1.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.7&title=v1.5.7&body=assisted-ui-lib-1.5.7%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.7