### PR TITLE
Pass list of enabled features

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
     "node-sass": "^4.13.1",
-    "openshift-assisted-ui-lib": "^1.5.7",
+    "openshift-assisted-ui-lib": "^1.5.7-1",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { Page } from '@patternfly/react-core';
-import { Store, Router as LibRouter } from 'openshift-assisted-ui-lib';
+import { Store, Router as LibRouter, Features } from 'openshift-assisted-ui-lib';
 import history from '../history';
 import Header from './ui/Header';
 // import Sidebar from './Sidebar';
@@ -23,7 +23,7 @@ const App: React.FC = () => (
         isManagedSidebar // enable this to automatically hide sidebar in mobile
         defaultManagedSidebarIsOpen={false}
       >
-        <LibRouter />
+        <LibRouter features={Features.STANDALONE_DEPLOYMENT_ENABLED_FEATURES} />
       </Page>
     </Router>
   </Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8690,10 +8690,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.7:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.7.tgz#7dc8a6372b0d25ad761b28f26160182918e08aab"
-  integrity sha512-dLhMqbKBBf+WiTwJgReWD95XxWAEROWVYNxkA9Ri8fZxQNc8L0PccP1y6ZsePObBkN7VHGAka5PJl6wKpqK/ng==
+openshift-assisted-ui-lib@^1.5.7-1:
+  version "1.5.7-1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.7-1.tgz#4a42c36bbbc6958550814a0c3dfa1c04d6c0b355"
+  integrity sha512-bTbvMtaOVTbdnu53El5NpGkxrJB86gmff9vZvr4UW92aOuPwDXcW7XNXbzxKOEN8emKhZr6ObhICsNp7D3A2BA==
   dependencies:
     axios-case-converter "^0.6.0"
     ip-address "^7.1.0"


### PR DESCRIPTION
In the stand-alone deployment, this list is hardcoded.
This list is expected to be dynamic in OCM only.

Requires: https://github.com/openshift-assisted/assisted-ui-lib/pull/439