### PR TITLE
Update openshift-assisted-ui-lib to 1.5.8-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
     "node-sass": "^4.13.1",
-    "openshift-assisted-ui-lib": "^1.5.8",
+    "openshift-assisted-ui-lib": "^1.5.8-1",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8695,10 +8695,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.8:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.8.tgz#73c20f18105b84edfa6bc04ec6c809ddeaed460b"
-  integrity sha512-h7++ivmimTMA/KZ7GdKoIVtBzeCbSvgb0Fb6mioidbXTMqXkrNQMEUmS0N3rFfomrbxy6GTzgEyj2DuwnuO0Fw==
+openshift-assisted-ui-lib@^1.5.8-1:
+  version "1.5.8-1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.8-1.tgz#f8ba0c3db03597f06363fb1743ecc1864feb8e5e"
+  integrity sha512-Kn2kDqUPjeLV2HtWFrilYyK+NhhIHtmSn/dDaOFJOqAJ0zYbWf4rWnIZarggWBm29jfSiweZ1TBYDdYCF52AjQ==
   dependencies:
     axios-case-converter "^0.6.0"
     ip-address "^7.1.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.8-1&title=v1.5.8-1&body=assisted-ui-lib-1.5.8-1%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.8-1