### PR TITLE
Update openshift-assisted-ui-lib to 1.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
     "node-sass": "^4.13.1",
-    "openshift-assisted-ui-lib": "^1.5.9",
+    "openshift-assisted-ui-lib": "^1.5.10",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8719,10 +8719,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.9:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.9.tgz#f22e5e46cc87ed8f84792e5386cdb801f6f1c7bc"
-  integrity sha512-l/8wkNt8o5iNlHOmXIc1glrEkWX3DKsfKOFwqmao4heLh5x++nwuRr+QPWc40BM6qMASLwoHaWZ1wxs7VhWAhA==
+openshift-assisted-ui-lib@^1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.10.tgz#bf71d92b74a19588dc5343a10b991305579c1a11"
+  integrity sha512-NAKSQ4Ydo7DdYL42KryKbA7oUauajXfnl+dmB82buSvZTTyZO0KY+FiYsad2n3GsH0H0qOnRlNV8UirKUSBOjg==
   dependencies:
     axios-case-converter "^0.6.0"
     filesize.js "^2.0.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.10&title=v1.5.10&body=assisted-ui-lib-1.5.10%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.10