### PR TITLE
Update openshift-assisted-ui-lib to 1.5.10-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,4 @@ You can learn more in the
 [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "humanize-plus": "^1.8.2",
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
-    "openshift-assisted-ui-lib": "^1.5.10-2",
+    "openshift-assisted-ui-lib": "^1.5.10-3",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8557,10 +8557,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.10-2:
-  version "1.5.10-2"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.10-2.tgz#5266e82272bb29bd4700ed7d586001558e019657"
-  integrity sha512-jRiMdlZBWZ7sTYktX08EHVjYl9xbc5LS0tm8j9zp4LGfb1KkBdNaV4kY0VGKZbD9yr1m2GZ5l4LkgyjO5stclQ==
+openshift-assisted-ui-lib@^1.5.10-3:
+  version "1.5.10-3"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.10-3.tgz#5baf6d465fb82c6b095580b76385b5c9ffb2f379"
+  integrity sha512-0pC0zAeSnF1QDq1B0zbC3dSV600rdV2Mpee3Mje2sSn3By8sqH0yTZjNFQTX9Jhnkqg/rRFOvIvORGzHQfbYvg==
   dependencies:
     axios-case-converter "^0.6.0"
     filesize.js "^2.0.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.10-3&title=v1.5.10-3&body=assisted-ui-lib-1.5.10-3%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.10-3