### PR TITLE
Update openshift-assisted-ui-lib to 1.5.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "humanize-plus": "^1.8.2",
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
-    "openshift-assisted-ui-lib": "^1.5.11",
+    "openshift-assisted-ui-lib": "^1.5.12",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8556,10 +8556,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.11.tgz#fc59f1b645bbc4878234c3ce630964f2035de600"
-  integrity sha512-C5eML3JazvURAGyF+F7oPIXPwl8WyexJJwuCcLex5xrXvbnO1pIpnJzeAsgwYJqGOp2TpXIjUR6k67wGWdCVNA==
+openshift-assisted-ui-lib@^1.5.12:
+  version "1.5.12"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.12.tgz#40788ace31ee2c662aad15d1e9d73b5c7b4e15b4"
+  integrity sha512-aa56qthULEk37BLd/XvQBoKiy0miUBl6JiyPAWdtMVpojUVOL6oTb/OlbwMChAZ28jZfdsAbfwZQfQplkbE2Mw==
   dependencies:
     axios-case-converter "^0.6.0"
     filesize.js "^2.0.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.12&title=v1.5.12&body=assisted-ui-lib-1.5.12%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.12