### PR TITLE
Updates for automation due to save changes

### DIFF
--- a/cypress/integration/shared/clusterConfiguration.ts
+++ b/cypress/integration/shared/clusterConfiguration.ts
@@ -111,6 +111,10 @@ export const waitForHostsToBeReady = (
 };
 
 export const setClusterSubnetCidr = (cy: Cypress.cy) => {
+  // it can take time for changes in the previous step to be saved
+  cy.get('#form-input-hostSubnet-field', { timeout: DEFAULT_SAVE_BUTTON_TIMEOUT }).should(
+    'be.visible',
+  );
   // select the first subnet from list
   cy.get('#form-input-hostSubnet-field')
     .find('option')
@@ -258,4 +262,9 @@ export const enableRoute53 = (cy: Cypress.cy) => {
 export const pressNext = (cy: Cypress.cy) => {
   cy.get('button[name="next"]', { timeout: PRESS_NEXT_TIMEOUT }).should('be.enabled');
   cy.get('button[name="next"]').click();
+};
+
+export const pressBack = (cy: Cypress.cy) => {
+  cy.get('button[name="back"]', { timeout: PRESS_NEXT_TIMEOUT }).should('be.enabled');
+  cy.get('button[name="back"]').click();
 };

--- a/cypress/integration/shared/clusterInstallation.ts
+++ b/cypress/integration/shared/clusterInstallation.ts
@@ -2,9 +2,12 @@ import {
   START_INSTALLATION_TIMEOUT,
   INSTALL_PREPARATION_TIMEOUT,
   CLUSTER_CREATION_TIMEOUT,
+  DEFAULT_SAVE_BUTTON_TIMEOUT,
 } from './constants';
 
 export const startClusterInstallation = (cy: Cypress.cy) => {
+  // it can take time for changes in the previous step to be saved
+  cy.get('button[name="install"', { timeout: DEFAULT_SAVE_BUTTON_TIMEOUT }).should('be.visible');
   // wait up to 10 seconds for the install button to be enabled
   cy.get('button[name="install"]', { timeout: START_INSTALLATION_TIMEOUT }).should(($elem) => {
     expect($elem).to.be.enabled;

--- a/cypress/integration/shared/constants.ts
+++ b/cypress/integration/shared/constants.ts
@@ -2,7 +2,7 @@
 export const DEFAULT_API_REQUEST_TIMEOUT = 20 * 1000;
 // create cluster button timeout
 export const DEFAULT_CREATE_CLUSTER_BUTTON_SHOW_TIMEOUT = 60 * 1000;
-// save buttone timeout - 30 seconds
+// save button timeout - 30 seconds
 export const DEFAULT_SAVE_BUTTON_TIMEOUT = 30 * 1000;
 // timeout for hosts to boot and register - 10 minutes
 export const HOST_REGISTRATION_TIMEOUT = 20 * 60 * 1000;


### PR DESCRIPTION
The wizard now saves changes when you press the "Next" button, which
causes delays in the appearance of the next page. The automation needs
to be adapt to it.