### PR TITLE
Increased timeouts

### DIFF
--- a/cypress/integration/shared/constants.ts
+++ b/cypress/integration/shared/constants.ts
@@ -24,8 +24,8 @@ export const FILE_DOWNLOAD_TIMEOUT = 60 * 1000;
 export const ISO_DOWNLOAD_TIMEOUT = 60 * 60 * 1000;
 // timeout for cluster installation to finish - 1.5 hour
 export const CLUSTER_CREATION_TIMEOUT = 90 * 60 * 1000;
-// searching for majority group can take up to 2 minutes
-export const HOSTS_DISCOVERY_TIMEOUT = 2.5 * 60 * 1000;
+// waiting for hosts discovery, as well as networking validations, can take time
+export const HOSTS_DISCOVERY_TIMEOUT = 5 * 60 * 1000;
 // time for "Next" to be enabled
 export const PRESS_NEXT_TIMEOUT = 60 * 1000;
 // time for the newly registered host to have a "role" column


### PR DESCRIPTION
Allow up to 5 minutes for the validations in the networking step to succeed.