### PR TITLE
Update openshift-assisted-ui-lib to 1.5.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "humanize-plus": "^1.8.2",
     "lodash": "^4.17.15",
     "netmask": "^1.0.6",
-    "openshift-assisted-ui-lib": "^1.5.12",
+    "openshift-assisted-ui-lib": "^1.5.13",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8556,10 +8556,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.12:
-  version "1.5.12"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.12.tgz#40788ace31ee2c662aad15d1e9d73b5c7b4e15b4"
-  integrity sha512-aa56qthULEk37BLd/XvQBoKiy0miUBl6JiyPAWdtMVpojUVOL6oTb/OlbwMChAZ28jZfdsAbfwZQfQplkbE2Mw==
+openshift-assisted-ui-lib@^1.5.13:
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.13.tgz#52ce63ad70dc60fc41edb0f0d0370ead568c948f"
+  integrity sha512-efBbTkYY0wKGKcN4CD8nfObLtD2yq9j+Eiod7+zo/gkxqvrw3tsbM0x4UtM+G2TcQTUcMk/uRWO6gIwhCABtPw==
   dependencies:
     axios-case-converter "^0.6.0"
     filesize.js "^2.0.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.13&title=v1.5.13&body=assisted-ui-lib-1.5.13%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.13