### PR TITLE
Update openshift-assisted-ui-lib to 1.5.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "human-date": "^1.4.0",
     "humanize-plus": "^1.8.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "^1.5.15-1",
+    "openshift-assisted-ui-lib": "^1.5.16",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8546,10 +8546,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.15-1:
-  version "1.5.15-1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.15-1.tgz#2320505009078781909592ec0c519658a31d96de"
-  integrity sha512-uktjVTO3fPE+EyddEGR7r6N7JkE6yLWnFQn1ajcHaSZ77ia62bprq7z4b564SUnPsxgBAJZ7av+zdkt3nQOT4A==
+openshift-assisted-ui-lib@^1.5.16:
+  version "1.5.16"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.16.tgz#375e17a4a3866dc46fd0456e459a4dacdc0bb5fb"
+  integrity sha512-pAtJxDQiXAXK5M3GcEbUvwHbCGMoSnAm1YD4TtRuDh2nKbibrGocKfGifNCLVyV9EVuaI0Y8B/NUSKeJJsY6sA==
   dependencies:
     axios-case-converter "^0.6.0"
     filesize.js "^2.0.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.16&title=v1.5.16&body=assisted-ui-lib-1.5.16%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.16