### PR TITLE
Update openshift-assisted-ui-lib to 1.5.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "human-date": "^1.4.0",
     "humanize-plus": "^1.8.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "^1.5.16",
+    "openshift-assisted-ui-lib": "1.5.17",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8546,10 +8546,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@^1.5.16:
-  version "1.5.16"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.16.tgz#375e17a4a3866dc46fd0456e459a4dacdc0bb5fb"
-  integrity sha512-pAtJxDQiXAXK5M3GcEbUvwHbCGMoSnAm1YD4TtRuDh2nKbibrGocKfGifNCLVyV9EVuaI0Y8B/NUSKeJJsY6sA==
+openshift-assisted-ui-lib@1.5.17:
+  version "1.5.17"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.17.tgz#410afa1bc3546e441cae8896775be99fe1d363be"
+  integrity sha512-SprXJPYPFtBv3Cl2py2n5imCg2Awm07s285jh4fLxWOOpJzFQi2rT8MSvnO3d4YdNXaEOD0E43sAXOqkoDxrMQ==
   dependencies:
     axios-case-converter "^0.6.0"
     filesize.js "^2.0.0"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.17&title=v1.5.17&body=assisted-ui-lib-1.5.17%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.17