### PR TITLE
Update openshift-assisted-ui-lib to 1.5.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "human-date": "^1.4.0",
     "humanize-plus": "^1.8.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.19",
+    "openshift-assisted-ui-lib": "1.5.20",
     "prettier": "^2.0.1",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5503,6 +5503,19 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+formik@2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.6.tgz#378a4bafe4b95caf6acf6db01f81f3fe5147559d"
+  integrity sha512-Kxk2zQRafy56zhLmrzcbryUpMBvT0tal5IvcifK5+4YNGelKsnrODFJ0sZQRMQboblWNym4lAW3bt+tf2vApSA==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.14"
+    lodash-es "^4.17.14"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
+
 formik@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/formik/-/formik-2.1.5.tgz#de5bbbe35543fa6d049fe96b8ee329d6cd6892b8"
@@ -8546,16 +8559,22 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.19:
-  version "1.5.19"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.19.tgz#8191195250b833ded660226f6b3b985c5d68a2aa"
-  integrity sha512-yVKQz4oIUkg8V2/34ioA5zYqddyZggRr3FQhRD5bUi0+r+ypndMTDHZKvEqxOVmIjRbvQD2Wav2f6ENm628Ueg==
+openshift-assisted-ui-lib@1.5.20:
+  version "1.5.20"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.20.tgz#7ccfc5ec191906bf9cd93028feb41038c03a791c"
+  integrity sha512-+7nchi8IHRICAxr+B+tj/i6Bo3y6pJ45ZZ6d20vswX60WNhz5Ato8SEyQJsnks2EsnWRmxbL2aovgpvWkzsmBQ==
   dependencies:
     axios-case-converter "^0.6.0"
+    file-saver "^2.0.2"
     filesize.js "^2.0.0"
+    formik "2.2.6"
+    http-proxy-middleware "^1.0.3"
+    human-date "^1.4.0"
+    humanize-plus "^1.8.2"
     ip-address "^7.1.0"
     is-cidr "^4.0.2"
     is-in-subnet "^3.1.0"
+    prism-react-renderer "^1.1.1"
     unique-names-generator "^4.2.0"
 
 opn@^5.5.0:


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.20&title=v1.5.20&body=assisted-ui-lib-1.5.20%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.20