### PR TITLE
Update openshift-assisted-ui-lib to 1.5.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "axios-case-converter": "^0.6.0",
     "http-proxy-middleware": "^1.0.3",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.20",
+    "openshift-assisted-ui-lib": "1.5.21",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8530,10 +8530,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.20:
-  version "1.5.20"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.20.tgz#7ccfc5ec191906bf9cd93028feb41038c03a791c"
-  integrity sha512-+7nchi8IHRICAxr+B+tj/i6Bo3y6pJ45ZZ6d20vswX60WNhz5Ato8SEyQJsnks2EsnWRmxbL2aovgpvWkzsmBQ==
+openshift-assisted-ui-lib@1.5.21:
+  version "1.5.21"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.21.tgz#edbf38dc7e7510bbcd97c61921dfb09c6205a2bf"
+  integrity sha512-n6z8BDK2MXVH86rBwJExFarMt3jZsXLLBbdmA6Dg3xfpX+BSUuqRTV3gC/Nx7iMTBI9WCpYqXvhO43b+s+LVuA==
   dependencies:
     axios-case-converter "^0.6.0"
     file-saver "^2.0.2"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.21&title=v1.5.21&body=assisted-ui-lib-1.5.21%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.21