### PR TITLE
Update openshift-assisted-ui-lib to 1.5.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "axios-case-converter": "^0.6.0",
     "http-proxy-middleware": "^1.0.3",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.21",
+    "openshift-assisted-ui-lib": "1.5.22",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6089,11 +6089,6 @@ http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
   integrity sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==
-  dependencies:
-    http-proxy "^1.17.0"
-    is-glob "^4.0.0"
-    lodash "^4.17.11"
-    micromatch "^3.1.10"
 
 http-proxy-middleware@^1.0.3:
   version "1.0.5"
@@ -8530,10 +8525,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.21:
-  version "1.5.21"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.21.tgz#edbf38dc7e7510bbcd97c61921dfb09c6205a2bf"
-  integrity sha512-n6z8BDK2MXVH86rBwJExFarMt3jZsXLLBbdmA6Dg3xfpX+BSUuqRTV3gC/Nx7iMTBI9WCpYqXvhO43b+s+LVuA==
+openshift-assisted-ui-lib@1.5.22:
+  version "1.5.22"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.22.tgz#b09024dbf188342668198d30ae89f667374791e4"
+  integrity sha512-Lje2Lamm9BNch2HBx2TJVBq0rsx2aFBe2OX414qE9Bc23kknzv+XBNeQTFuVuMwMEmHzH/Y9S9scCxfhFvthZg==
   dependencies:
     axios-case-converter "^0.6.0"
     file-saver "^2.0.2"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.22&title=v1.5.22&body=assisted-ui-lib-1.5.22%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.22