### PR TITLE
Update openshift-assisted-ui-lib to 1.5.22-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "axios-case-converter": "^0.6.0",
     "http-proxy-middleware": "^1.0.3",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.22",
+    "openshift-assisted-ui-lib": "1.5.22-1",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6101,7 +6101,7 @@ http-proxy-middleware@^1.0.3:
     lodash "^4.17.19"
     micromatch "^4.0.2"
 
-http-proxy@^1.17.0, http-proxy@^1.18.1:
+http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -8525,10 +8525,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.22:
-  version "1.5.22"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.22.tgz#b09024dbf188342668198d30ae89f667374791e4"
-  integrity sha512-Lje2Lamm9BNch2HBx2TJVBq0rsx2aFBe2OX414qE9Bc23kknzv+XBNeQTFuVuMwMEmHzH/Y9S9scCxfhFvthZg==
+openshift-assisted-ui-lib@1.5.22-1:
+  version "1.5.22-1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.22-1.tgz#90234344c6309db66ede3c5bf3498665c4da4c80"
+  integrity sha512-Ah0mUFlSfV8a+4OIu3lj2EXvQKAaqjy7tXDu1pYMjsMgP0wmLaKn4D+teLF8HRfol+xIY7uFmt9rwVNh88ggyA==
   dependencies:
     axios-case-converter "^0.6.0"
     file-saver "^2.0.2"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.22-1&title=v1.5.22-1&body=assisted-ui-lib-1.5.22-1%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.22-1