### PR TITLE
Update openshift-assisted-ui-lib to 1.5.23-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "axios-case-converter": "^0.6.0",
     "http-proxy-middleware": "^1.0.3",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.23",
+    "openshift-assisted-ui-lib": "1.5.23-1",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6145,7 +6145,7 @@ http-proxy-middleware@^1.0.3:
     lodash "^4.17.19"
     micromatch "^4.0.2"
 
-http-proxy@^1.17.0, http-proxy@^1.18.1:
+http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -8581,10 +8581,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.23:
-  version "1.5.23"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.23.tgz#6fdf93464e501a6b8ce14e32334401783a2e5205"
-  integrity sha512-upCZ5RyB/DA2TYyD8/51BTBNojSyJw5ocjwjN4fwKTGxL0zxvFvwTmVm72s+cdDL0JoBr6sr+1ro7yU6eK3okw==
+openshift-assisted-ui-lib@1.5.23-1:
+  version "1.5.23-1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.23-1.tgz#5608f285726fb98751efe201ed102eb60fbc329a"
+  integrity sha512-h56V+7ftJzak+upo0GWvTSTMaJcSJVyeod5qucRi/bA2+8JzsOHVO3l3r0fjDSjHNDpiWrtlC7vB1AazKJ6qpw==
   dependencies:
     axios-case-converter "^0.6.0"
     file-saver "^2.0.2"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.23-1&title=v1.5.23-1&body=assisted-ui-lib-1.5.23-1%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.23-1