### PR TITLE
Update openshift-assisted-ui-lib to 1.5.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "axios-case-converter": "^0.6.0",
     "http-proxy-middleware": "^1.0.3",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.23-1",
+    "openshift-assisted-ui-lib": "1.5.24",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8581,10 +8581,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.23-1:
-  version "1.5.23-1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.23-1.tgz#5608f285726fb98751efe201ed102eb60fbc329a"
-  integrity sha512-h56V+7ftJzak+upo0GWvTSTMaJcSJVyeod5qucRi/bA2+8JzsOHVO3l3r0fjDSjHNDpiWrtlC7vB1AazKJ6qpw==
+openshift-assisted-ui-lib@1.5.24:
+  version "1.5.24"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.24.tgz#88c80a3c0cdaa15c11fca7fd8766709b19017bb3"
+  integrity sha512-WDUglIoKUkUHCL66Wks1yPAH2fU67nGsW5xNt1cfV2+MtbkhUA8eqKuFNmzoEC7aphs5vAMFW6sHjLsTRpFjrw==
   dependencies:
     axios-case-converter "^0.6.0"
     file-saver "^2.0.2"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.24&title=v1.5.24&body=assisted-ui-lib-1.5.24%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.24