### PR TITLE
Update openshift-assisted-ui-lib to 1.5.24-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "axios-case-converter": "^0.6.0",
     "http-proxy-middleware": "^1.0.3",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.24",
+    "openshift-assisted-ui-lib": "1.5.24-2",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,6 +6133,11 @@ http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
   integrity sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==
+  dependencies:
+    http-proxy "^1.17.0"
+    is-glob "^4.0.0"
+    lodash "^4.17.11"
+    micromatch "^3.1.10"
 
 http-proxy-middleware@^1.0.3:
   version "1.0.5"
@@ -8581,10 +8586,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.24:
-  version "1.5.24"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.24.tgz#88c80a3c0cdaa15c11fca7fd8766709b19017bb3"
-  integrity sha512-WDUglIoKUkUHCL66Wks1yPAH2fU67nGsW5xNt1cfV2+MtbkhUA8eqKuFNmzoEC7aphs5vAMFW6sHjLsTRpFjrw==
+openshift-assisted-ui-lib@1.5.24-2:
+  version "1.5.24-2"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.24-2.tgz#d9cd7b6327cba9a5d12c72ed4692c22412f096af"
+  integrity sha512-YKNUirNIoSMS4GcItGhgZmcYVIhM0d2VcF/fakSD1AK3olMM/Fwn+z2Sd6to06yIHCcXSoNAog40yqRIMbNaxg==
   dependencies:
     axios-case-converter "^0.6.0"
     file-saver "^2.0.2"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.24-2&title=v1.5.24-2&body=assisted-ui-lib-1.5.24-2%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.24-2