### PR TITLE
Update openshift-assisted-ui-lib to 1.5.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "axios-case-converter": "^0.6.0",
     "http-proxy-middleware": "^1.0.3",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.26",
+    "openshift-assisted-ui-lib": "1.5.27",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6138,6 +6138,11 @@ http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
   integrity sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==
+  dependencies:
+    http-proxy "^1.17.0"
+    is-glob "^4.0.0"
+    lodash "^4.17.11"
+    micromatch "^3.1.10"
 
 http-proxy-middleware@^1.0.3:
   version "1.0.5"
@@ -6150,7 +6155,7 @@ http-proxy-middleware@^1.0.3:
     lodash "^4.17.19"
     micromatch "^4.0.2"
 
-http-proxy@^1.17.0, http-proxy@^1.18.1:
+http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -8586,10 +8591,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.26:
-  version "1.5.26"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.26.tgz#9b5456af47a338818e95466600fcef871abf5c29"
-  integrity sha512-/arBGbKQliNtZXXLRnGv+fwkY4cJUqREbwGslidd1UYyi6VS1sxSjDnbnQdkGqYB36c2dxOd/iepYADYQFBCrg==
+openshift-assisted-ui-lib@1.5.27:
+  version "1.5.27"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.27.tgz#060c0579505a8ade84ad0069082398bb43312669"
+  integrity sha512-L/fTu8s+MgNchuoremNKa+Z6U+TawcYZmtCeG5RTQqOySImfLMJyBFLr5T924O+FnTYw44ZnleycgTlhg6ohLA==
   dependencies:
     axios-case-converter "^0.6.0"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.27&title=v1.5.27&body=assisted-ui-lib-1.5.27%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.27