### PR TITLE
Update openshift-assisted-ui-lib to 1.5.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "axios-case-converter": "^0.6.0",
     "http-proxy-middleware": "^1.0.3",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.27-1",
+    "openshift-assisted-ui-lib": "1.5.28",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8591,10 +8591,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.27-1:
-  version "1.5.27-1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.27-1.tgz#655365148cdeed6258a19c485dccec7cc6811f4f"
-  integrity sha512-xrsAeQinVnWLhdhgHsRXi8l5eTGeE+QXMxH+wwJKVIANip9bdidStxcMkqkwBWfRbklU3h+bC6Ur7yzjfjRoMg==
+openshift-assisted-ui-lib@1.5.28:
+  version "1.5.28"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.28.tgz#93ed5727957b90dac0e4892c70abe5f0947cdbd7"
+  integrity sha512-Iy7MyyFmiEIR1KxLmpfcAeOvkBD1qbsOuLIh0UAMLZShd+OS6luD+0qVPi5usQ54y24nnGa1tEf2i+oOb42r8A==
   dependencies:
     axios-case-converter "^0.6.0"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.28&title=v1.5.28&body=assisted-ui-lib-1.5.28%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.28