### PR TITLE
MGMT-7375: Restores a missing CSS import

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -6,3 +6,4 @@
 */
 @import '~@patternfly/patternfly/patternfly.css';
 @import '~@patternfly/patternfly/patternfly-addons.css';
+@import '~openshift-assisted-ui-lib/dist/index.css';


### PR DESCRIPTION
Related to: [TechPreview badge style is misplaced](https://issues.redhat.com/browse/MGMT-7375)
![image](https://user-images.githubusercontent.com/87187179/126994383-85cfc5a7-fe30-4db7-af89-63f4b2ea6c52.png)
