### PR TITLE
Update openshift-assisted-ui-lib to 1.5.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.33",
+    "openshift-assisted-ui-lib": "1.5.34",
     "prettier": "^2.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8616,10 +8616,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.33:
-  version "1.5.33"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.33.tgz#df1b396243a8c48448dbf78523e9232f6f1dd12c"
-  integrity sha512-WD/dRapPxU5DtbSni8jfy9Jqmx4M0tZJYqVoeuPagabwPTPmeAaCkJTy1EZEavZ07tNMOpDV3wOloLWk3B79lA==
+openshift-assisted-ui-lib@1.5.34:
+  version "1.5.34"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.34.tgz#7f4d1f1b37f219b02d602bc008856b2bbabd88a0"
+  integrity sha512-1/B7ICPFgGNU+iVorHc2wvVoIFirAknTD2dSRy42NrVATPKwNTp+q9R/z46OBj4uGfQ1/74/N0An4vLq+udGoA==
   dependencies:
     axios-case-converter "^0.6.0"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.34&title=v1.5.34&body=assisted-ui-lib-1.5.34%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.34