### PR TITLE
Update openshift-assisted-ui-lib to 1.5.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.34",
+    "openshift-assisted-ui-lib": "1.5.35",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8074,10 +8074,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.34:
-  version "1.5.34"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.34.tgz#7f4d1f1b37f219b02d602bc008856b2bbabd88a0"
-  integrity sha512-1/B7ICPFgGNU+iVorHc2wvVoIFirAknTD2dSRy42NrVATPKwNTp+q9R/z46OBj4uGfQ1/74/N0An4vLq+udGoA==
+openshift-assisted-ui-lib@1.5.35:
+  version "1.5.35"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.35.tgz#ab72b6046b0f8f3295f8724c5a13ae606dc4a41b"
+  integrity sha512-jHHZxlr1Dnk61iZwhoKc69BJ/qtKzPDnXDdmDzeRKHlqxKFcYDZlmudLyTKA8s+msfJZiXYmjJyBXOa0AjJVzQ==
   dependencies:
     axios-case-converter "^0.6.0"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.35&title=v1.5.35&body=assisted-ui-lib-1.5.35%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.35