### PR TITLE
Update openshift-assisted-ui-lib to 1.5.39-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.37",
+    "openshift-assisted-ui-lib": "1.5.39-2",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8113,10 +8113,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.37:
-  version "1.5.37"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.37.tgz#b97104cc607d3bedcdf4bdde180dbdffe1d0d3ad"
-  integrity sha512-lwZun3Fureox9TNODv8mwkJPFzKh/MNZUKb5wuuYWR2IUWJSpowMB3TTpSgRHcQO8XmntCnEARNf0HpJcXaH8g==
+openshift-assisted-ui-lib@1.5.39-2:
+  version "1.5.39-2"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.39-2.tgz#887af1a073f1180306fbe4443f5ebcad0fe974ba"
+  integrity sha512-x7/5U9J9dXGNXQZJcAjZHmvlN2gWVs2cPHrZ3Sb8keWO3OxAxE00ujsgGne5cizk1gZ35P6pUP0qe3h2sCZ00A==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.39-2&title=v1.5.39-2&body=assisted-ui-lib-1.5.39-2%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.39-2