### PR TITLE
Update openshift-assisted-ui-lib to 1.5.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.41",
+    "openshift-assisted-ui-lib": "1.5.42",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8113,10 +8113,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.41:
-  version "1.5.41"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.41.tgz#b533e98df6b9240aa8830f520a546db1ea069a9c"
-  integrity sha512-ZWB7ve7UHt/9xW4+VD7Hxy6wZ5BoVQR1+gV9vbWQYCZR92luW2jUyNuN55ss2VxEmL7ZCLOgTuFFFxT82+1ifA==
+openshift-assisted-ui-lib@1.5.42:
+  version "1.5.42"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.42.tgz#8d273f632bd32c16df624dd0e03a02b19c3ee7ce"
+  integrity sha512-WePiluT5lhgGmPghOBxScGBkyp902Feecrn+MqkMrkQjZiBBmMvc98pDx2H8/2UcJucSnOUqtLSL0QwmpQCDuw==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: Once this PR is merged, continue by creating a new release here:
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.42&title=v1.5.42&body=assisted-ui-lib-1.5.42%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.42