### PR TITLE
Update openshift-assisted-ui-lib to 1.5.43-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.43",
+    "openshift-assisted-ui-lib": "1.5.43-1",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8348,10 +8348,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.43:
-  version "1.5.43"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.43.tgz#bf7b1cc56757eeee2f95f4c06c47b0d6deb035b9"
-  integrity sha512-n/MOBKfF3fixh1zzLahhTwy5wcjmRnMNxuZIaj3aebnmz3I6fsujq0Gq6oUroMha0xKuXIQ3V83w7ohL4oA/lA==
+openshift-assisted-ui-lib@1.5.43-1:
+  version "1.5.43-1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.43-1.tgz#350043591157139c3692de2d3bd9a1bbe30c5152"
+  integrity sha512-ljBLV4mUdHyFuAbugsDa9Rwtv4ZERYlGRzn4ErFPOXQ97QHdvhb2zcMzuxJdoH1Hod/40Xz4CJbKf2n++ZojRQ==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v1.5.43-1&title=v1.5.43-1&body=assisted-ui-lib-1.5.43-1%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv1.5.43-1)