### PR TITLE
Update openshift-assisted-ui-lib to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "1.5.45",
+    "openshift-assisted-ui-lib": "2.0.0",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8113,10 +8113,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@1.5.45:
-  version "1.5.45"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-1.5.45.tgz#8fb67c0c59eb697e084c7e8d5d80509e02a0d16a"
-  integrity sha512-iJK1K77mcUZzm5HSSG7tU47QJImxFGHscOqecbjfKlzu4O3Vsz/ZCtuwy1g54sl6/bhxRLLFJLn/CSpLOji+Sg==
+openshift-assisted-ui-lib@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.0.tgz#f36495ddce959dc948029720ac026ba8435c2cbf"
+  integrity sha512-roubKj0UnkTtSPBXTy4asg/+MjemFlL+uXCC05J1FuAd4d5AAFQoRougB4UeQcGgFbZaAGmGkgZAYjAFQHzdMg==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v2.0.0&title=v2.0.0&body=assisted-ui-lib-2.0.0%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv2.0.0)
depends on #508 