### PR TITLE
MGMT-7808: Moving to quay.io/edge-infrastructure

### DIFF
--- a/.github/workflows/mergeToSelectedBranches.yaml
+++ b/.github/workflows/mergeToSelectedBranches.yaml
@@ -49,12 +49,12 @@ jobs:
         run: yarn lint
       - name: Build code
         run: yarn build
-      - name: Publish to quay.io
+      - name: Publish to quay.io/edge-infrastructure
         uses: elgohr/Publish-Docker-Github-Action@2.14
         with:
-          name: ocpmetal/ocp-metal-ui
-          username: ${{ secrets.QUAYIO_OCPMETAL_USERNAME }}
-          password: ${{ secrets.QUAYIO_OCPMETAL_PASSWORD }}
+          name: edge-infrastructure/assisted-installer-ui
+          username: ${{ secrets.QUAYIO_EDGE_INFRA_USERNAME }}
+          password: ${{ secrets.QUAYIO_EDGE_INFRA_PASSWORD }}
           registry: quay.io
           dockerfile: Dockerfile
           tags: '${{ env.IMAGE_TAGS }}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,10 +36,10 @@ jobs:
         run: yarn lint
       - name: Build code
         run: yarn build
-      - name: Publish to quay.io
+      - name: Publish to quay.io/edge-infrastructure
         uses: elgohr/Publish-Docker-Github-Action@2.14
         with:
-          name: ocpmetal/ocp-metal-ui
+          name: edge-infrastructure/assisted-installer-ui
           username: ${{ secrets.QUAYIO_OCPMETAL_USERNAME }}
           password: ${{ secrets.QUAYIO_OCPMETAL_PASSWORD }}
           registry: quay.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/nginx:1.18.0
 
 COPY deploy/deploy_config.sh /deploy/
-COPY deploy/ocp-metal-ui-template.yaml /deploy/
+COPY deploy/ui-deployment-template.yaml /deploy/
 
 COPY build/ /app/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: all build deploy clean
 
-IMAGE := $(or ${IMAGE},quay.io/ocpmetal/ocp-metal-ui:latest)
+IMAGE := $(or ${IMAGE},quay.io/edge-infrastructure/assisted-installer-ui:latest)
 NAMESPACE := $(or ${NAMESPACE},assisted-installer)
 ASSISTED_SERVICE_URL := $(or ${ASSISTED_SERVICE_URL},http://assisted-service.${NAMESPACE}.svc.cluster.local:8090)
-DEPLOY_FILE="deploy/ocp-metal-ui.yaml"
+DEPLOY_FILE="deploy/assisted-installer-ui.yaml"
 
 all: build deploy
 
@@ -14,11 +14,11 @@ build:
 
 deploy:
 	mkdir -p build/deploy/
-	deploy/deploy_config.sh -u "${ASSISTED_SERVICE_URL}" -i "${IMAGE}" -t deploy/ocp-metal-ui-template.yaml -n "${NAMESPACE}" > ${DEPLOY_FILE}
+	deploy/deploy_config.sh -u "${ASSISTED_SERVICE_URL}" -i "${IMAGE}" -t deploy/ui-deployment-template.yaml -n "${NAMESPACE}" > ${DEPLOY_FILE}
 	kubectl apply -f ${DEPLOY_FILE}
 
 # TODO(mlibra): Run tests: get UI URL, run run-tests.sh
 
 clean:
 	rm -f ${DEPLOY_FILE}
-	kubectl delete deployment,service,configmap ocp-metal-ui
+	kubectl delete deployment,service,configmap assisted-installer-ui

--- a/deploy/deploy_config.sh
+++ b/deploy/deploy_config.sh
@@ -9,8 +9,8 @@ usage() {
 
 ASSISTED_SERVICE_URL="http://assisted-service.__NAMESPACE__.svc.cluster.local:8090"
 DIRECTORY=$(dirname "$0")
-INPUT_TEMPLATE="${DIRECTORY}/ocp-metal-ui-template.yaml"
-IMAGE="quay.io/ocpmetal/ocp-metal-ui:latest"
+INPUT_TEMPLATE="${DIRECTORY}/ui-deployment-template.yaml"
+IMAGE=${IMAGE:-"quay.io/edge-infrastructure/assisted-installer-ui:latest"}
 NAMESPACE="assisted-installer"
 
 while getopts ":u:i:t:n:h" opt; do

--- a/deploy/ui-deployment-template.yaml
+++ b/deploy/ui-deployment-template.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: ocp-metal-ui
+  name: assisted-installer-ui
   namespace: "__NAMESPACE__"
 spec:
   type: LoadBalancer
@@ -11,12 +11,12 @@ spec:
       protocol: TCP
       # nodePort: 31000
   selector:
-    app: ocp-metal-ui
+    app: assisted-installer-ui
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: ocp-metal-ui
+  name: assisted-installer-ui
   namespace: "__NAMESPACE__"
 data:
   nginx.conf: |
@@ -48,20 +48,20 @@ data:
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: ocp-metal-ui
+  name: assisted-installer-ui
   namespace: "__NAMESPACE__"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ocp-metal-ui
+      app: assisted-installer-ui
   template:
     metadata:
       labels:
-        app: ocp-metal-ui
+        app: assisted-installer-ui
     spec:
       containers:
-        - name: ocp-metal-ui
+        - name: assisted-installer-ui
           image: __IMAGE__
           imagePullPolicy: Always
           ports:
@@ -73,7 +73,7 @@ spec:
       volumes:
         - name: nginx-conf
           configMap:
-            name: ocp-metal-ui
+            name: assisted-installer-ui
             items:
               - key: nginx.conf
                 path: default.conf


### PR DESCRIPTION
This renames the k8s service, configmap and deployment from `ocp-metal-ui` to `assisted-installer-ui`