### PR TITLE
Update openshift-assisted-ui-lib to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "2.0.0",
+    "openshift-assisted-ui-lib": "2.0.3",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-assisted-ui",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "private": false,
   "license": "Apache-2.0",
   "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8113,10 +8113,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.0.tgz#f36495ddce959dc948029720ac026ba8435c2cbf"
-  integrity sha512-roubKj0UnkTtSPBXTy4asg/+MjemFlL+uXCC05J1FuAd4d5AAFQoRougB4UeQcGgFbZaAGmGkgZAYjAFQHzdMg==
+openshift-assisted-ui-lib@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.3.tgz#bbe507b5126a612ffcfa55851965b6f89833ae28"
+  integrity sha512-c80Oz8gs93orhEYNsunNIFGnceSI45QMUsezbSQruYLAOSj7sgwf/GmfNWGUJ/pkYFDcr+JGKjV7TId/5DJZIg==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"
@@ -8124,7 +8124,6 @@ openshift-assisted-ui-lib@2.0.0:
     filesize.js "^2.0.0"
     formik "2.2.6"
     fuse.js "^6.4.6"
-    http-proxy-middleware "^1.0.3"
     human-date "^1.4.0"
     humanize-plus "^1.8.2"
     ip-address "^7.1.0"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v2.0.3&title=v2.0.3&body=assisted-ui-lib-2.0.3%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv2.0.3)