### PR TITLE
Update openshift-assisted-ui-lib to 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-assisted-ui",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": false,
   "license": "Apache-2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.15",
-    "openshift-assisted-ui-lib": "2.0.4",
+    "openshift-assisted-ui-lib": "2.0.5",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8113,10 +8113,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.4.tgz#9a5cbdd270591496d1ede375f20db3a70872c182"
-  integrity sha512-k1JeqQdSbr0pTvTGUaQdIg1xePnb8ZS/DZFUW3/q4qBPLvnpBLiFpqqPj8kiMrToM4LeUfbrXY9yeJBA/dvDuQ==
+openshift-assisted-ui-lib@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.5.tgz#482d8933e4aa354f0a694d35366d749d22d9d735"
+  integrity sha512-qHfdMcKK5XVyuiq/3HF5cbICpUrPZmhYoCRx78VnQWWae67BbIgM0KqekveyaG5jC232FhN2Ey8cTGpvsGMolQ==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v2.0.5&title=v2.0.5&body=assisted-ui-lib-2.0.5%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv2.0.5)