### PR TITLE
Update openshift-assisted-ui-lib to 2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.0.6-1",
+    "openshift-assisted-ui-lib": "2.0.7",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8113,10 +8113,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.0.6-1:
-  version "2.0.6-1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.6-1.tgz#73146c5bf3d07783421e320efbe9d080e64f39c2"
-  integrity sha512-yfrI7k3fhTvZGhiHEpJAN8Q9rDRmjHv4gkuQJSRVuXvk7QAwbZOZhtGIv2iO/CSaFvtMkmzF6c/b0l/rz6c4YQ==
+openshift-assisted-ui-lib@2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.7.tgz#7a5e7c5293f2ccd05c196a6df22d114d7eee1880"
+  integrity sha512-D29sOlccv44t0+arukr4NXO8vnWVM4jj5xNQBKzzpZ2tuTq7Bjy3UzUMHAKYT7xokk1AynjtrDSP/l20Awg+Yg==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v2.0.7&title=v2.0.7&body=assisted-ui-lib-2.0.7%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv2.0.7)