### PR TITLE
Update openshift-assisted-ui-lib to 2.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.0.7-1",
+    "openshift-assisted-ui-lib": "2.0.8",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8108,10 +8108,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.0.7-1:
-  version "2.0.7-1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.7-1.tgz#f3447129a59a2abc4eae9eedd7095d88f64cbf16"
-  integrity sha512-b4iekHaN/c0c8kC+XldEWVDeDiurfSx2OXauy2SNLmY83m2BiTMuABmz0yDaEjbq5qNvoW6B5w/xPQwgsAN96w==
+openshift-assisted-ui-lib@2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.8.tgz#f8cc270380297b91c86331f6cf4f0f1788eca3d7"
+  integrity sha512-FKquaAAr2rQkT2pGi4pQCZOYgbpJJmaq+Z6FCVQ2yU5p8BXvznncGSJK97P/Vx7guCqmZyV81PXgHNk3kBV2RQ==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v2.0.8&title=v2.0.8&body=assisted-ui-lib-2.0.8%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv2.0.8)