### PR TITLE
Update openshift-assisted-ui-lib to 2.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.0.9",
+    "openshift-assisted-ui-lib": "2.0.10",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-assisted-ui",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": false,
   "license": "Apache-2.0",
   "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8108,10 +8108,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.0.9:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.9.tgz#485f76873c263466a3aa695fbc340eaf5a301050"
-  integrity sha512-j7tvH3iN4uUk/aMmS9Aue897wyOc8f+YDDmQgzuux1cMmE/PVtC0TC40pAGePmOfEsuu68huxm1Ob0h51C79fA==
+openshift-assisted-ui-lib@2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.10.tgz#927a619850599a99261a678662d0969ae6b87df9"
+  integrity sha512-N2Bw6yegj7BoEt6L0MtAgFQ0ebXfpD1EVTbZSniGFXzHfanTdljQoWuFC+l+mHFV8nB7Cxrq5GTJ3uKvYy0prg==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v2.0.10&title=v2.0.10&body=assisted-ui-lib-2.0.10%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv2.0.10)