### PR TITLE
Update openshift-assisted-ui-lib to 2.0.9-3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.1.0",
+    "openshift-assisted-ui-lib": "2.0.9-3",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-assisted-ui",
-  "version": "2.1.0",
+  "version": "2.0.9-3",
   "private": false,
   "license": "Apache-2.0",
   "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8108,10 +8108,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.1.0.tgz#35989813fc9be29f15efa596965b34f60b801255"
-  integrity sha512-Ul2jHmVQFEmJv7kUvO9QBdb87lbdKmsKfULq8+XP0pQNBlkCobbXXNuI+D2X4Z8RT099JHWypDol4VAZdJqWTw==
+openshift-assisted-ui-lib@2.0.9-3:
+  version "2.0.9-3"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.0.9-3.tgz#651c6cdc12db458c021c6a060f2b6d2a1e38ac79"
+  integrity sha512-1CqfLuStTqigtM1eqT/XdZBphLcxyhYwNw7AXulJm83SNLHW1wwprW+RTRVKhhvhHJIdV0RdG7nheUzc6rQK0w==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v2.0.9-3&title=v2.0.9-3&body=assisted-ui-lib-2.0.9-3%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv2.0.9-3)