### PR TITLE
Fixed the Assisted UI not working with disabled IPv6 issue

### DIFF
--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -4,4 +4,10 @@ export ASSISTED_SERVICE_URL="${ASSISTED_SERVICE_URL:-http://localhost:8090}"
 
 envsubst '$ASSISTED_SERVICE_URL' < /deploy/nginx.conf > "$NGINX_DEFAULT_CONF_PATH/nginx.conf"
 
+# Do not listen on IPv6 if it's not enabled in the hardware
+if grep 'ipv6.disable=1' /proc/cmdline; then
+    cp "${NGINX_CONF_PATH}" ~/nginx.conf.orig
+    sed -e 's/listen\s*\[::\].*//g' ~/nginx.conf.orig | dd of="${NGINX_CONF_PATH}"
+fi
+
 exec nginx -g "daemon off;"


### PR DESCRIPTION
nginx log the following error: `nginx: [emerg] socket() [::]:8080 failed (97: Address family not supported by protocol)`

Due to the known issue with the Nginx, disabling IPv6 in the default configuration will cause it to fail to start.

This patch fixes this issue by testing during the runtime for disabled IPv6 and updating the Nginx configuration.

https://issues.redhat.com/browse/MGMT-9342