### PR TITLE
Custom Dockerfile and container build script

### DIFF
--- a/hacks/build_image.sh
+++ b/hacks/build_image.sh
@@ -1,24 +1,40 @@
 #!/usr/bin/env bash
 set -e
 
+DOCKERFILE="./Dockerfile"
+REACT_APP_BUILD_MODE=""
+
 usage() {
-  echo "Usage: $0 [ single-cluster ]" 1>&2
+cat << EOF
+This command must be executed from the root of the repository
+Usage: $0 [-f <dockerfile>] [-s|--single-cluster]
+EOF
 }
 
 parse_args() {
-  while getopts ":h" opt; do
+  while getopts ":f:sh" opt; do
     case $opt in
       h)
         usage
         exit 0
         ;;
+      s)
+        REACT_APP_BUILD_MODE="single-cluster"
+        ;;
+      f)
+        DOCKERFILE="$OPTARG"
+        ;;
       \?)
-        echo "Invalid option: -$OPTARG" >&2
+        echo "Invalid option: -${opt}" >&2
         usage
         exit 1
         ;;
       :)
-        echo "Option -$OPTARG requires an argument." >&2
+        echo "Option -$opt requires an argument." >&2
+        usage
+        exit 1
+        ;;
+      *)
         usage
         exit 1
         ;;
@@ -33,12 +49,23 @@ find_tool() {
 main() {
   parse_args "$@"
   PODMAN=$(find_tool)
+
+  pushd ../assisted-ui-lib
+  REACT_APP_GIT_SHA="$(git rev-parse --short HEAD)"
+  popd
+  REACT_APP_VERSION="$(git rev-parse --short HEAD)"
+
+  if [ "$DOCKERFILE" != './Dockerfile' ]; then
+    yarn build
+  fi
+
   ${PODMAN} build \
+    -f "$DOCKERFILE" \
     --force-rm \
-    --tag assisted-installer-ui:"${1:-local}" \
-    --build-arg=REACT_APP_BUILD_MODE="$1" \
-    --build-arg=REACT_APP_GIT_SHA="$(git rev-parse HEAD)" \
-    --build-arg=REACT_APP_VERSION=latest \
+    --tag quay.io/"$(whoami)"/assisted-installer-ui:"$REACT_APP_GIT_SHA" \
+    --build-arg=REACT_APP_BUILD_MODE="$REACT_APP_BUILD_MODE" \
+    --build-arg=REACT_APP_GIT_SHA="$REACT_APP_GIT_SHA" \
+    --build-arg=REACT_APP_VERSION="$REACT_APP_VERSION" \
     .
 }
 

--- a/hacks/custom.Dockerfile
+++ b/hacks/custom.Dockerfile
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi8/nginx-120 as app
+
+# persist these on the final image for later inspection
+ARG REACT_APP_BUILD_MODE
+ENV BUILD_MODE=$REACT_APP_BUILD_MODE
+ARG REACT_APP_GIT_SHA
+ENV GIT_SHA=$REACT_APP_GIT_SHA
+ARG REACT_APP_VERSION
+ENV VERSION=$REACT_APP_VERSION
+
+COPY ../deploy/deploy_config.sh /deploy/
+COPY ../deploy/ui-deployment-template.yaml /deploy/
+COPY ../deploy/nginx.conf /deploy/
+COPY ../deploy/start.sh /deploy/
+
+COPY --chown=1001:0 /build/ "${NGINX_APP_ROOT}/src/"
+
+CMD [ "/deploy/start.sh" ]


### PR DESCRIPTION
This PR adds a *custom Dockerfile* and a *build script*
- The *custom Dockerfile* allows building the container image outside of the UBI as opposite to the Dockerfile located at the root of the repo. 
This is useful for preparing custom builds of the UI.
- The build script just runs `docker` or `podman` and builds the image, it is there mainly to not have to memorize the entire syntax for the build command.