### PR TITLE
Update openshift-assisted-ui-lib to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-assisted-ui",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": false,
   "license": "Apache-2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.1.1",
+    "openshift-assisted-ui-lib": "2.1.2",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8108,10 +8108,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.1.1.tgz#9b8315c96edf24a3a82e82af1f66947f7d77ea08"
-  integrity sha512-OYLg+uuBGuHZbfIfaI8rzxMObHWV+ZMkcYyT0Yezd0e6w4e+0d8E7amSTfLKx7wZTWcWJ+YXntcIQXEadNEPkQ==
+openshift-assisted-ui-lib@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.1.2.tgz#0a22d31919dd400532ee02a746332414a5af9349"
+  integrity sha512-ZYlrGTZE56gQ6pe436IPL5TJbuU9ZvQUr6t33XiJ/sPcrevQjMcPzqHEADTs5zxK5gUexizVM+yv1PqmWlaLlw==
   dependencies:
     axios-case-converter "^0.8.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Instructions: once this PR is merged, continue by creating a new release [here](
https://github.com/openshift-assisted/assisted-ui/releases/new?tag=v2.1.2&title=v2.1.2&body=assisted-ui-lib-2.1.2%3A%20https%3A%2F%2Fgithub.com%2Fopenshift-assisted%2Fassisted-ui-lib%2Freleases%2Ftag%2Fv2.1.2)