### PR TITLE
Import only OCM as a module to reduce build time

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -5,7 +5,7 @@ import {
   TextContent,
   ButtonVariant,
 } from '@patternfly/react-core';
-import { OCM } from 'openshift-assisted-ui-lib';
+import * as OCM from 'openshift-assisted-ui-lib/dist/ocm';
 import { GIT_SHA, VERSION, SERVICE_LABELS, IMAGE_REPO } from '../config/standalone';
 import redHatLogo from '../images/Logo-Red_Hat-OpenShift_Container_Platform-B-Reverse-RGB.png';
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { Page } from '@patternfly/react-core';
-import { OCM } from 'openshift-assisted-ui-lib';
+import * as OCM from 'openshift-assisted-ui-lib/dist/ocm';
 import history from '../history';
 import Header from './ui/Header';
 // import Sidebar from './Sidebar';

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Brand, PageHeader, PageHeaderTools, Button, ButtonVariant } from '@patternfly/react-core';
-import { OCM } from 'openshift-assisted-ui-lib';
+import * as OCM from 'openshift-assisted-ui-lib/dist/ocm';
 import upstreamLogo from '../../images/metal3_facet-whitetext.png';
 import redhatLogo from '../../images/Logo-Red_Hat-OpenShift_Container_Platform-B-Reverse-RGB.png';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';

--- a/src/openshift-assisted-ui-lib.d.ts
+++ b/src/openshift-assisted-ui-lib.d.ts
@@ -1,0 +1,3 @@
+declare module 'openshift-assisted-ui-lib/dist/ocm' {
+  export * from 'openshift-assisted-ui-lib/dist/src/ocm';
+}


### PR DESCRIPTION
Similar to this PR https://github.com/openshift-assisted/assisted-ui-lib/pull/1250, by importing only OCM in `assisted-ui`, we reduce significantly the build time when working on "dev" mode and we apply changes to `assisted-ui-lib`.

In my machine, the rebuild time went from over a minute to aprox. 20 seconds. I think this could be further improved as explained in the PR for `assisted-ui-lib`. I'd appreciate if as part of the review, you could test this locally as well.

I checked also that it doesn't impact the rebuild times for changes on `assisted-ui`

