### PR TITLE
NO_ISSUE: Added react-error-boundary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "swr": "^0.5.6",
     "typescript": "^3.8.3",
     "unique-names-generator": "^4.2.0",
+    "react-error-boundary": "^3.1.4",
     "uuid": "^8.1.0",
     "yup": "^0.28.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,6 +1168,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.2.0":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
@@ -9601,6 +9608,13 @@ react-dropzone@9.0.0:
     file-selector "^0.1.8"
     prop-types "^15.6.2"
     prop-types-extra "^1.1.0"
+
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.7:
   version "6.0.7"


### PR DESCRIPTION
This is a dependency of assisted-ui-lib. 
New dependencies of the lib break the development environment until the lib is published to NPM.
As a workaround this new dependency is added to assisted-ui as well to not break the dev env.
This dependency is added as part of Static IP feature.
https://issues.redhat.com/browse/MGMT-8081