### PR TITLE
Updates openshift-assisted-ui-lib to 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.6.5",
+    "openshift-assisted-ui-lib": "2.7.0",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8168,10 +8168,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.6.5.tgz#c3bf7233b7041f36c94efb05b3cce6188df8c1c3"
-  integrity sha512-NkfKQ5CMuo1+CXzySTla8tmTsLmWHoX+3mqrg9ztn5M/oaRRlW3B522ui45LWxJrbqOFapp8EBN71xwooqxdiA==
+openshift-assisted-ui-lib@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.0.tgz#c78feffdf79b6c0b2a0992b2ca645430971ae52b"
+  integrity sha512-XL2qG9CJCC90y/3H+CbWSg5LmHVtX+IsKJXJ1x2VKLdnn5BWeyZHDdQX3jCtdsJ/lijY52BXp85isLrxWKQSCw==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.7.0)
cc @openshift-assisted/ui-maintainers