### PR TITLE
Updates openshift-assisted-ui-lib to 2.6.1-cim

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.7.0",
+    "openshift-assisted-ui-lib": "2.6.1-cim",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8168,10 +8168,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.0.tgz#c78feffdf79b6c0b2a0992b2ca645430971ae52b"
-  integrity sha512-XL2qG9CJCC90y/3H+CbWSg5LmHVtX+IsKJXJ1x2VKLdnn5BWeyZHDdQX3jCtdsJ/lijY52BXp85isLrxWKQSCw==
+openshift-assisted-ui-lib@2.6.1-cim:
+  version "2.6.1-cim"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.6.1-cim.tgz#6fec41a6bcf0b321b0a36ccbcef96d4c0114ee1e"
+  integrity sha512-avJbPFL9Ddzi4riiMG3yOUsaxoUWV9RIV37OngV/QWDg86YKPTSmi/33PmeI95C9Tprkv639pmK/skEv/UyMEg==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.6.1-cim)
cc @openshift-assisted/ui-maintainers