### PR TITLE
Updates openshift-assisted-ui-lib to 2.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.7.3",
+    "openshift-assisted-ui-lib": "2.7.4",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8168,10 +8168,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.7.3:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.3.tgz#22a288ec2823f4f1dba83d23f14b7066766ecbba"
-  integrity sha512-sLklUD2fhrZBb+F/l2ZT8pY23J5g+yHI73MUBsDvtfziLrX15/mn0EZq14qFOVtz4voGdmZ+XExUe+P+yu1d9g==
+openshift-assisted-ui-lib@2.7.4:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.4.tgz#afc90f50a4a5a3075a876893695d14f054dcbc43"
+  integrity sha512-ZUhp9vaMUQB055vlZYXlA6+pBrqGD52U4L2Jtw0F50313YzGWLQrvCGXdYYPRUgDki8ytYjQnI46mAQn1LqZWA==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.7.4)
cc @openshift-assisted/ui-maintainers