### PR TITLE
Updates openshift-assisted-ui-lib to 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.7.5",
+    "openshift-assisted-ui-lib": "2.8.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8168,10 +8168,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.7.5:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.5.tgz#094e51fa1850eb0bd77a7b4201dde17b0e4c9e82"
-  integrity sha512-coyT2NPPk3Son4v1UmcAZVfcbdVcAG3iubkeiNRjlIOAIGBF8U7aRBBwzrXcHGYaN5pmaXBE1YV1vfjWiLKDcg==
+openshift-assisted-ui-lib@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.8.1.tgz#60b7680b71b89397360eebee7f9d8f7d7e769a73"
+  integrity sha512-vT2B2L8bSJuNCtRkwtlkfSONra8J8TMuVFnnend4VV8agBhrK2SxHvhubUHf/9mn7BpzJdNAKorFpPqATNrlog==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.8.1)
cc @openshift-assisted/ui-maintainers