### PR TITLE
Updates openshift-assisted-ui-lib to 2.6.2-cim

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.8.2",
+    "openshift-assisted-ui-lib": "2.6.2-cim",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8168,10 +8168,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.8.2.tgz#c1f39734c8361e6c7af43458518997645060ae09"
-  integrity sha512-+vGiBpBGVDsu0FDkqMfLhZ/huQ5sBlIDBAlHY6tdiaYaDKjyXrVjZxNFpzbt2BJ5kWaWL1UEntlC5D3YqXJkIg==
+openshift-assisted-ui-lib@2.6.2-cim:
+  version "2.6.2-cim"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.6.2-cim.tgz#daabc306f0bc2bf41149cbee0b534885f7e302db"
+  integrity sha512-HxW0xSPXLGV2CqxaSH/DUKSvNuYFO5MCHjVimBK8WDbpcd4JglVjNpQwEEx0Xju1eLDg1IOLbrX66qTMDnAuew==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.6.2-cim)
cc @openshift-assisted/ui-maintainers