### PR TITLE
MGMT-11857: Support nginx SSL configuration

### DIFF
--- a/deploy/nginx_ssl.conf
+++ b/deploy/nginx_ssl.conf
@@ -1,0 +1,9 @@
+ server {
+    listen 443 ssl;
+
+    ssl_certificate     $HTTPS_CERT_FILE;
+    ssl_certificate_key $HTTPS_KEY_FILE;
+
+    ssl_verify_client       on;
+    ssl_ocsp                on;
+}

--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -4,6 +4,12 @@ export ASSISTED_SERVICE_URL="${ASSISTED_SERVICE_URL:-http://localhost:8090}"
 
 envsubst '$ASSISTED_SERVICE_URL' < /deploy/nginx.conf > "$NGINX_DEFAULT_CONF_PATH/nginx.conf"
 
+if [ "$ASSISTED_SERVICE_SCHEME" = "https" ]; then
+    envsubst 'HTTPS_CERT_FILE' < /deploy/nginx_ssl.conf > "/deploy/nginx_ssl.conf.tmp"
+    envsubst 'HTTPS_KEY_FILE'  < /deploy/nginx_ssl.conf.tmp > "$NGINX_DEFAULT_CONF_PATH/nginx_ssl.conf"
+    rm -f "/deploy/nginx_ssl.conf.tmp"
+fi
+
 # Do not listen on IPv6 if it's not enabled in the hardware
 if grep 'ipv6.disable=1' /proc/cmdline; then
     cp "${NGINX_CONF_PATH}" ~/nginx.conf.orig


### PR DESCRIPTION
In a case where ASSISTED_SERVICE_SCHEME is set to https, the
generated nginx configuration should be set to ssl