### PR TITLE
MGMT-11857: Add support for nginx SSL configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ENV VERSION=$REACT_APP_VERSION
 COPY deploy/deploy_config.sh /deploy/
 COPY deploy/ui-deployment-template.yaml /deploy/
 COPY deploy/nginx.conf /deploy/
+COPY deploy/nginx_ssl.conf /deploy/
 COPY deploy/start.sh /deploy/
 
 COPY --from=builder /src/build/ "${NGINX_APP_ROOT}/src/"

--- a/deploy/nginx_ssl.conf
+++ b/deploy/nginx_ssl.conf
@@ -1,9 +1,46 @@
- server {
-    listen 443 ssl;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
 
-    ssl_certificate     $HTTPS_CERT_FILE;
-    ssl_certificate_key $HTTPS_KEY_FILE;
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
 
-    ssl_verify_client       on;
-    ssl_ocsp                on;
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       8080 ssl;
+        listen       [::]:8080 ssl;
+
+        ssl_certificate     $HTTPS_CERT_FILE;
+        ssl_certificate_key $HTTPS_KEY_FILE;
+
+        server_name  _;
+        root         /opt/app-root/src;
+
+        # Load configuration files for the default server block.
+        include /opt/app-root/etc/nginx.default.d/*.conf;
+    }
 }

--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -5,9 +5,7 @@ export ASSISTED_SERVICE_URL="${ASSISTED_SERVICE_URL:-http://localhost:8090}"
 envsubst '$ASSISTED_SERVICE_URL' < /deploy/nginx.conf > "$NGINX_DEFAULT_CONF_PATH/nginx.conf"
 
 if [ "$ASSISTED_SERVICE_SCHEME" = "https" ]; then
-    envsubst 'HTTPS_CERT_FILE' < /deploy/nginx_ssl.conf > "/deploy/nginx_ssl.conf.tmp"
-    envsubst 'HTTPS_KEY_FILE'  < /deploy/nginx_ssl.conf.tmp > "$NGINX_DEFAULT_CONF_PATH/nginx_ssl.conf"
-    rm -f "/deploy/nginx_ssl.conf.tmp"
+    envsubst '${HTTPS_CERT_FILE} ${HTTPS_KEY_FILE}' < /deploy/nginx_ssl.conf > "${NGINX_CONF_PATH}"
 fi
 
 # Do not listen on IPv6 if it's not enabled in the hardware


### PR DESCRIPTION
In a case where `$ASSISTED_SERVICE_SCHEME` is set to HTTPS, the
generated nginx configuration should be set to SSL