### PR TITLE
Updates openshift-assisted-ui-lib to 2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.10.0",
+    "openshift-assisted-ui-lib": "2.11.0",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,10 +8183,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.10.0.tgz#593137408ba2fd54045d8d24a58b22ab391ea9c5"
-  integrity sha512-vBpLAX9NC9Hm+bcCm8CW77n0ERdwH8Oejhsp1Fqj/jh6N3b+dTDnPcod0l/Y9cw4KfSC4Et75jDFucJMwwIlnA==
+openshift-assisted-ui-lib@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.11.0.tgz#07b660ab753dff6379f769258dedd80aa0c0a5b2"
+  integrity sha512-memtbfHylROuckHcmSQ24PFIlcaSSfjz/WqTVYPjetEabsi7MXiEtwRhMiQ6jsndS1R/Hi6wnRjO+x4Eyx1FSQ==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.11.0)
cc @openshift-assisted/ui-maintainers