### PR TITLE
Updates openshift-assisted-ui-lib to 2.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.11.0",
+    "openshift-assisted-ui-lib": "2.11.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,10 +8183,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.11.0.tgz#07b660ab753dff6379f769258dedd80aa0c0a5b2"
-  integrity sha512-memtbfHylROuckHcmSQ24PFIlcaSSfjz/WqTVYPjetEabsi7MXiEtwRhMiQ6jsndS1R/Hi6wnRjO+x4Eyx1FSQ==
+openshift-assisted-ui-lib@2.11.1:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.11.1.tgz#b5112ccf13b18b50858ac42f5e57c8cb586bd769"
+  integrity sha512-3THsvxjMBvC88CwOp3dN2YppnRvtFYT39aNUvKALe5TPc/v8Y77WmOxB+qA/OH7dkneJMGEVO3vhQVQfLEbz2A==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.11.1)
cc @openshift-assisted/ui-maintainers