### PR TITLE
Updates openshift-assisted-ui-lib to 2.7.0-cim

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.11.3",
+    "openshift-assisted-ui-lib": "2.7.0-cim",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,10 +8183,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.11.3:
-  version "2.11.3"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.11.3.tgz#15c8f72d200014a1e7da91b5a463417179dd9937"
-  integrity sha512-DphHX/WJAc0OvWftiz0sN1g3yJheFKVqlvqsAqTACjxzpL/Rq3pSlLunM/h/ZWJwxsNaaPlUT5DJPJiq/nGtqA==
+openshift-assisted-ui-lib@2.7.0-cim:
+  version "2.7.0-cim"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.0-cim.tgz#249a8541f2d28885a58904e0f3a7cc64b4131afa"
+  integrity sha512-dqhDjp0mNCOxXvS8Qm/4SlKTBKowQ5ljE2BUDXsF9IjDrAfOWfmlxLp+ZeSIA5a1AlA+QRPUuMg3l/Ua74Kuwg==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.7.0-cim)
cc @openshift-assisted/ui-maintainers