### PR TITLE
Updates openshift-assisted-ui-lib to 2.6.6-cim

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.12.0",
+    "openshift-assisted-ui-lib": "2.6.6-cim",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,10 +8183,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.12.0.tgz#a76be8ed2cf8918f1d32009cbb485d221d3b7ddf"
-  integrity sha512-3ZxuP1ypsKKS49SdDG8tf6BUTtuH9kOzIGizxgfDlk6GEwnmAY3MhE9F2Ix8JLpwNOlgJsXWPlSlmxAkApxGWA==
+openshift-assisted-ui-lib@2.6.6-cim:
+  version "2.6.6-cim"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.6.6-cim.tgz#c0dabe4198a24624845b75e91e05dd8f1d8857e9"
+  integrity sha512-cid6T+csfNXL0iPNxOvckrUPysX4hTWPz/SWstBU2IsW6hl/UdbU0iis7SN8CdPukMnxd3Mx4YwBiGBNInXcZw==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.6.6-cim)
cc @openshift-assisted/ui-maintainers