### PR TITLE
Updates openshift-assisted-ui-lib to 2.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.12.0",
+    "openshift-assisted-ui-lib": "2.12.1",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,10 +8183,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.12.0.tgz#a76be8ed2cf8918f1d32009cbb485d221d3b7ddf"
-  integrity sha512-3ZxuP1ypsKKS49SdDG8tf6BUTtuH9kOzIGizxgfDlk6GEwnmAY3MhE9F2Ix8JLpwNOlgJsXWPlSlmxAkApxGWA==
+openshift-assisted-ui-lib@2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.12.1.tgz#bc593c038fa246fbae753a120758e66af464cfd8"
+  integrity sha512-Dge/5bWIBOsqbGGfZRz+RleEz1RE2WK4LANsmV6sMfpt8TnUDj7tpmoEhEDYMH+RlDnQ/dOZEf+kq08kfO7lJA==
   dependencies:
     axios-case-converter "^0.8.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.12.1)
cc @openshift-assisted/ui-maintainers