### PR TITLE
Update Github actions to use Node v16

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: '12'
+          node-version: 16
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -38,7 +38,7 @@ jobs:
           containerfiles: ./Dockerfile
 
       - name: Push the assisted-ui image to Quay.io
-        uses: redhat-actions/push-to-registry@v2.6
+        uses: redhat-actions/push-to-registry@v2.7
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}


### PR DESCRIPTION
Same upgrade as in https://github.com/openshift-assisted/assisted-ui-lib/pull/1855/files

Avoid using older redhat-actions which use Node v12 (which has been deprecated).
See output in https://github.com/openshift-assisted/assisted-ui/actions/runs/3910112839