### PR TITLE
Updates openshift-assisted-ui-lib to 2.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.15.1",
+    "openshift-assisted-ui-lib": "2.15.2",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8486,10 +8486,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.15.1:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.15.1.tgz#e0d71c3d53d60c5775ee3ef6ec461895f6edef76"
-  integrity sha512-tRDzCfYZpjqzPF20AcCMaGqjytidcLPbLqBDkFE5Xvvy8jpndDFnWZl7ogmPpiGN9Uz6USjOkNa/msdEyY4LWw==
+openshift-assisted-ui-lib@2.15.2:
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.15.2.tgz#2c3705f73957afcbcdc67d25afd9d5479c39f765"
+  integrity sha512-1lybHesH8KzrOH++llS8mNWUOy+ntfL8VBwKII/ZDryfSKAceJXTLgK2wFEDtcszfKFshLP16RIusvfe9TZkiw==
   dependencies:
     axios-case-converter "^0.11.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.15.2)
cc @openshift-assisted/ui-maintainers