### PR TITLE
Updates openshift-assisted-ui-lib to 2.16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.16.1",
+    "openshift-assisted-ui-lib": "2.16.2",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8486,10 +8486,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.16.1.tgz#bfa45f6f7b58ba8d346f58098d910d9ac052ed39"
-  integrity sha512-mv/enl98QPDWz6/cnyFVG+Ms9XkQtUUp9IwPm1ixueu9UksO7MBpv1jO6C+FbtFQI9joRdbhF45+p//avBDzCQ==
+openshift-assisted-ui-lib@2.16.2:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.16.2.tgz#b0c6b701cdd5efd1639b322c6b13777287c73a25"
+  integrity sha512-kREfV3/4CxXoU/rU9bUJ953URwnh+qw/NULnX5XPsUfCBI0lMS96673fhMC0ufL2vObsy3km6V1zz9z89Sg8Eg==
   dependencies:
     axios-case-converter "^0.11.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.16.2)
cc @openshift-assisted/ui-maintainers