### PR TITLE
Updates openshift-assisted-ui-lib to 2.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.16.2",
+    "openshift-assisted-ui-lib": "2.16.3",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8486,10 +8486,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.16.2:
-  version "2.16.2"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.16.2.tgz#b0c6b701cdd5efd1639b322c6b13777287c73a25"
-  integrity sha512-kREfV3/4CxXoU/rU9bUJ953URwnh+qw/NULnX5XPsUfCBI0lMS96673fhMC0ufL2vObsy3km6V1zz9z89Sg8Eg==
+openshift-assisted-ui-lib@2.16.3:
+  version "2.16.3"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.16.3.tgz#75b01883149da5785069cd0f2c064cfd5514eb8f"
+  integrity sha512-TuvfYe6NSGDQZQv+KRhUbscdFdf0iwyfafhCIHOD6UzV//TCXKLiufxwHa+MgW25acGzj8/unsBxYQfGtdhwgw==
   dependencies:
     axios-case-converter "^0.11.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.16.3)
cc @openshift-assisted/ui-maintainers