### PR TITLE
Updates openshift-assisted-ui-lib to 2.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.21",
-    "openshift-assisted-ui-lib": "2.16.3",
+    "openshift-assisted-ui-lib": "2.17.0",
     "react": "^16.14.0",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8486,10 +8486,10 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openshift-assisted-ui-lib@2.16.3:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.16.3.tgz#75b01883149da5785069cd0f2c064cfd5514eb8f"
-  integrity sha512-TuvfYe6NSGDQZQv+KRhUbscdFdf0iwyfafhCIHOD6UzV//TCXKLiufxwHa+MgW25acGzj8/unsBxYQfGtdhwgw==
+openshift-assisted-ui-lib@2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.17.0.tgz#d0a314e13e47b60f69ec4ef0428b2df7af4cff74"
+  integrity sha512-H/K2hHU4BR3t/Aqr6YYMC+GzzOFcbkzVCGg+eW5q7Cn3r2djTlZH2xq31ms4O1HADc6D6Sv2E2E1TdNPfyHUUw==
   dependencies:
     axios-case-converter "^0.11.1"
     cidr-tools "^4.3.0"


### PR DESCRIPTION
[Release notes](https://github.com/openshift-assisted/assisted-ui-lib/releases/tag/v2.17.0)
cc @openshift-assisted/ui-maintainers